### PR TITLE
fix(st-switch): Switch does not change when user clicks on it twice

### DIFF
--- a/src/lib/st-switch/st-switch.component.ts
+++ b/src/lib/st-switch/st-switch.component.ts
@@ -29,10 +29,10 @@ export class StSwitchComponent implements ControlValueAccessor {
    @Input() label: string;
    @Input() labelPosition: 'top' | 'right' | 'left' = 'top';
    @Input() contextualHelp: string;
+   @Input() disabled: boolean;
    @Output() change: EventEmitter<boolean> = new EventEmitter<boolean>();
-
+   
    public _stModel: boolean;
-   public disabled: boolean;
    private registeredOnChange: (_: any) => void;
 
    constructor(private _cd: ChangeDetectorRef) {

--- a/src/lib/st-switch/st-switch.html
+++ b/src/lib/st-switch/st-switch.html
@@ -12,7 +12,7 @@
              [name]="name"
              [attr.type]="'checkbox'"
              [checked]="stModel"
-             (click)="onChange($event.target.checked)"
+             (change)="onChange($event.target.checked)"
              [attr.data-qa]="label + ' ' + name"
       />
    </div>


### PR DESCRIPTION
## TYPE
- Bugfix

## Description
Switch does not change when user clicks on it twice

### Documentation
- [ ] Have explained API (Inputs, Outpus, Models, Functions, etc)
- [ ] Have example running
- [ ] Have example code (HTML, ts)
- [ ] Have changelog.md updated

### Code
- [ ] Have 3 spaces indentation
- [ ] Pass ts lint Task
- [ ] Pass Sass lint Task
- [ ] Have QA-tags

### Tests
- [ ] Have 70% Tests coverage

### Other observations
- Add other information you consider important

### Post-review reminder
- Remember reviewer approve changes inside the Files Changed tab (Review changes dropdown)
- Squash commits
- Release version in case of breaking changes and notify of all front
