### PR TITLE
fix(st-switch): Switch component emits event twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3.0 (upcoming)
 
-* Pending changelog
+* Bugfix st-switch component emits event twice
 
 ## 2.2.2 (June 06, 2017)
 

--- a/src/lib/st-switch/st-switch.component.spec.ts
+++ b/src/lib/st-switch/st-switch.component.spec.ts
@@ -99,7 +99,7 @@ describe('StSwitchComponent', () => {
          fixture.detectChanges();
          fixture.changeDetectorRef.markForCheck();
 
-         expect(component._stModel).toBeTruthy();
+         expect(component.stModel).toBeTruthy();
          expect(component.change.emit).toHaveBeenCalledWith(true);
          expect(switchBox.classList).toContain('st-switch--on');
 
@@ -107,7 +107,7 @@ describe('StSwitchComponent', () => {
          fixture.detectChanges();
          fixture.changeDetectorRef.markForCheck();
 
-         expect(component._stModel).toBeFalsy();
+         expect(component.stModel).toBeFalsy();
          expect(component.change.emit).toHaveBeenCalledWith(false);
          expect(switchBox.classList).toContain('st-switch--off');
       });
@@ -123,7 +123,7 @@ describe('StSwitchComponent', () => {
          fixture.detectChanges();
          fixture.changeDetectorRef.markForCheck();
 
-         expect(component._stModel).toBeFalsy();
+         expect(component.stModel).toBeFalsy();
          expect(component.change.emit).not.toHaveBeenCalled();
          expect(switchBox.classList).toContain('st-switch--off');
 
@@ -131,7 +131,7 @@ describe('StSwitchComponent', () => {
          fixture.detectChanges();
          fixture.changeDetectorRef.markForCheck();
 
-         expect(component._stModel).toBeFalsy();
+         expect(component.stModel).toBeFalsy();
          expect(component.change.emit).not.toHaveBeenCalled();
          expect(switchBox.classList).toContain('st-switch--off');
       });
@@ -172,10 +172,12 @@ describe('StSwitchComponent', () => {
 
    it('Callback function is initialized on registerOnChange function in order to be called when there is a change', () => {
       let callbackFunction = jasmine.createSpy('callbackFunction');
-
       component.registerOnChange(callbackFunction);
+      component.stModel = false;
+      fixture.detectChanges();
 
-      component.onChange(true);
+      let switchBox: HTMLDivElement = fixture.nativeElement.querySelector('.st-switch__toggle');
+      switchBox.click();
 
       expect(callbackFunction).toHaveBeenCalledWith(true);
    });
@@ -189,7 +191,7 @@ describe('StSwitchComponent', () => {
 
       let switchBox: HTMLDivElement = fixture.nativeElement.querySelector('.st-switch__toggle');
 
-      expect(component._stModel).toBeTruthy();
+      expect(component.stModel).toBeTruthy();
       expect(switchBox.classList).toContain('st-switch--on');
 
       model = false;
@@ -199,7 +201,7 @@ describe('StSwitchComponent', () => {
 
       switchBox = fixture.nativeElement.querySelector('.st-switch__toggle');
 
-      expect(component._stModel).toBeFalsy();
+      expect(component.stModel).toBeFalsy();
       expect(switchBox.classList).toContain('st-switch--off');
    });
 

--- a/src/lib/st-switch/st-switch.component.spec.ts
+++ b/src/lib/st-switch/st-switch.component.spec.ts
@@ -184,7 +184,7 @@ describe('StSwitchComponent', () => {
 
    it('If model is changed from outside, switch is updated', () => {
       spyOn(component.change, 'emit').and.callThrough();
-      let model: boolean = true;
+      model = true;
       component.stModel = model;
       fixture.detectChanges();
       fixture.changeDetectorRef.markForCheck();

--- a/src/lib/st-switch/st-switch.component.ts
+++ b/src/lib/st-switch/st-switch.component.ts
@@ -33,7 +33,7 @@ export class StSwitchComponent implements ControlValueAccessor {
    @Input() name: string;
    @Output() change: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-   public _stModel: boolean;
+   private _stModel: boolean;
    private registeredOnChange: (_: any) => void;
 
    constructor(private _cd: ChangeDetectorRef) {
@@ -57,8 +57,7 @@ export class StSwitchComponent implements ControlValueAccessor {
 
    // load external change
    writeValue(value: boolean): void {
-      this.onChange(value);
-      this._cd.markForCheck();
+      this._stModel = value;
    }
 
    // internal change callback
@@ -74,8 +73,10 @@ export class StSwitchComponent implements ControlValueAccessor {
       this._cd.markForCheck();
    }
 
-   onChange(value: boolean): void {
+   onChange(event: MouseEvent): void {
       if (!this.disabled) {
+         event.stopPropagation();
+         let value: boolean = (<HTMLInputElement> event.target).checked;
          this._stModel = value;
          this.change.emit(this._stModel);
          if (this.registeredOnChange) {

--- a/src/lib/st-switch/st-switch.html
+++ b/src/lib/st-switch/st-switch.html
@@ -3,14 +3,14 @@
                [contextualHelp]="contextualHelp"
                [status]="getLabelStatus()">
    <div class="st-switch__toggle sth-switch__toggle" [attr.id]="qaTag"
-        [ngClass]="{ 'st-switch--disabled': disabled, 'st-switch--on': stModel, 'st-switch--off': !stModel, 'st-switch__label--top': labelPosition === 'top'}">
+        [ngClass]="{ 'st-switch--disabled': disabled, 'st-switch--on': _stModel, 'st-switch--off': !_stModel, 'st-switch__label--top': labelPosition === 'top'}">
       <div class="st-switch__box sth-switch__box">
          <span class="st-switch__circle sth-switch__circle"></span>
       </div>
       <input class="st-switch__input"
              [name]="name"
              [attr.type]="'checkbox'"
-             [checked]="_stModel"
+             [checked]="stModel"
              (change)="onChange($event)"
              [attr.id]="label + ' ' + name"
       />

--- a/src/lib/st-switch/st-switch.html
+++ b/src/lib/st-switch/st-switch.html
@@ -3,7 +3,7 @@
                [contextualHelp]="contextualHelp"
                [status]="getLabelStatus()">
    <div class="st-switch__toggle sth-switch__toggle" [attr.id]="qaTag"
-        [ngClass]="{ 'st-switch--disabled': disabled, 'st-switch--on': _stModel, 'st-switch--off': !_stModel, 'st-switch__label--top': labelPosition === 'top'}">
+        [ngClass]="{ 'st-switch--disabled': disabled, 'st-switch--on': stModel, 'st-switch--off': !stModel, 'st-switch__label--top': labelPosition === 'top'}">
       <div class="st-switch__box sth-switch__box">
          <span class="st-switch__circle sth-switch__circle"></span>
       </div>
@@ -11,7 +11,7 @@
              [name]="name"
              [attr.type]="'checkbox'"
              [checked]="_stModel"
-             (change)="onChange($event.target.checked)"
+             (change)="onChange($event)"
              [attr.id]="label + ' ' + name"
       />
    </div>


### PR DESCRIPTION
## TYPE
- Bugfix
Close #EGE-271

## Description
Switch component emits event twice when user interacts with it

### Documentation
- [ ] Have explained API (Inputs, Outpus, Models, Functions, etc)
- [ ] Have example running
- [ ] Have example code (HTML, ts)
- [x] Have changelog.md updated

### Code
- [x] Have 3 spaces indentation
- [x] Pass ts lint Task
- [ ] Pass Sass lint Task
- [x] Have QA-tags

### Tests
- [x] Have 70% Tests coverage

### Other observations
- Add other information you consider important

### Post-review reminder
- Remember reviewer approve changes inside the Files Changed tab (Review changes dropdown)
- Squash commits
- Release version in case of breaking changes and notify of all front
