### PR TITLE
fix(st-search): Send event with an empty search when user presses the cross button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 **Fixed bugs:**
 
 * st-page-title: Fix bug when page is refreshed, the editable page title is displayed wrong
+* st-search: Send an empty search when the user presses the cross button
 
 **Breaking changes:**
 

--- a/src/egeo-demo/st-search-demo/st-search-demo.ts
+++ b/src/egeo-demo/st-search-demo/st-search-demo.ts
@@ -58,7 +58,6 @@ export class StSearchDemoComponent {
    }
 
    searchWithAutocompleteSearch(searchValue: string): void {
-      console.log('search');
       this.searchedAutocomplete = searchValue;
       this.filter(searchValue);
    }

--- a/src/lib/st-search/st-search.component.spec.ts
+++ b/src/lib/st-search/st-search.component.spec.ts
@@ -256,7 +256,8 @@ describe('StSearchComponent', () => {
       expect(responseFunction).toHaveBeenCalledWith('test');
    });
 
-   it('should be able to clear on click', () => {
+   it('should be able to clean the search text when user clicks on the cross button and event is emitted with an empty search', () => {
+      spyOn(comp.search, 'emit');
       comp.debounce = 0;
       comp.minLength = 0;
 
@@ -273,7 +274,9 @@ describe('StSearchComponent', () => {
       expect(comp.searchBox.value).toEqual('test');
 
       clearButton.nativeElement.dispatchEvent(new Event('mousedown'));
+
       expect(comp.searchBox.value).toEqual('');
+      expect(comp.search.emit).toHaveBeenCalledWith('');
    });
 
    it('should be able to change initial Values', () => {

--- a/src/lib/st-search/st-search.component.ts
+++ b/src/lib/st-search/st-search.component.ts
@@ -123,6 +123,7 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
    public clearInput(): void {
       this.searchBox.setValue('');
       this.closeElement();
+      this.emitValue(true);
    }
 
    private emitValue(force: boolean): void {


### PR DESCRIPTION
Close #CCT-119
### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app

### Code
- [x] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [x] Have at least 70% tests coverage