### PR TITLE
fix(st-search): Cherry pick "Send event with an empty search when user presses the cross button"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixed bugs:**
 
 * st-page-title: Fix bug when page is refreshed, the editable page title is displayed wrong
+* st-search: Send an empty search when the user presses the cross button
 
 **Breaking changes:**
 

--- a/src/lib/st-search/demo/st-search-demo.ts
+++ b/src/lib/st-search/demo/st-search-demo.ts
@@ -82,7 +82,6 @@ export class StSearchDemoComponent {
    }
 
    searchWithAutocompleteSearch(searchValue: string): void {
-      console.log('search');
       this.searchedAutocomplete = searchValue;
       this.filter(searchValue);
    }

--- a/src/lib/st-search/st-search.component.spec.ts
+++ b/src/lib/st-search/st-search.component.spec.ts
@@ -261,7 +261,8 @@ describe('StSearchComponent', () => {
       expect(responseFunction).toHaveBeenCalledWith('test');
    });
 
-   it('should be able to clear on click', () => {
+   it('should be able to clean the search text when user clicks on the cross button and event is emitted with an empty search', () => {
+      spyOn(comp.search, 'emit');
       comp.debounce = 0;
       comp.minLength = 0;
 
@@ -278,7 +279,9 @@ describe('StSearchComponent', () => {
       expect(comp.searchBox.value).toEqual('test');
 
       clearButton.nativeElement.dispatchEvent(new Event('mousedown'));
+
       expect(comp.searchBox.value).toEqual('');
+      expect(comp.search.emit).toHaveBeenCalledWith('');
    });
 
    it('should be able to change initial Values', () => {

--- a/src/lib/st-search/st-search.component.ts
+++ b/src/lib/st-search/st-search.component.ts
@@ -132,6 +132,7 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
    public clearInput(): void {
       this.searchBox.setValue('');
       this.closeElement();
+      this.emitValue(true);
    }
 
    private emitValue(force: boolean): void {


### PR DESCRIPTION
Close #CCT-119

### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage