### PR TITLE
refactor(st-select):  Output emitted when select is changed is now the value of the option instead of the entire option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,11 @@
 * st-header: Models change of name
 * st-header: Change general behaviour and design
 * st-input-adjustable: Rename directive 'StInputAdjustable' to st-input-adjustable
-* st-switch: Remove labelPosition input, label always are dispayed at the left.
+* st-switch: Remove labelPosition input, label always are dispayed at the left
 * st-horizontal-tabs: Event emitted when active tabs changes, now sends the option of type StHorizontalTab 
 * st-horizontal-tabs: Removed functionality to display disabled tabs
 * st-button: Removed component now use native tag and classes
+* st-select: Output emitted when select is changed is now the value of the option instead of the entire option
 
 **Refactor**
 

--- a/src/egeo-demo/st-select-demo/select-demo.ts
+++ b/src/egeo-demo/st-select-demo/select-demo.ts
@@ -32,13 +32,15 @@ export class SelectDemoComponent {
    public reactiveForm: FormGroup; // our model driven form
 
    constructor(private _fb: FormBuilder) {
+      this.options.push({label: 'Select an option', value: undefined});
       for (let i: number = 0; i < 10; i++) {
          this.options.push({
             label: `option-${i}`,
             value: i
          });
       }
-      this.model.option2 = this.options[2];
+      this.model.option1 = 3;
+      this.model.option2 = 2;
 
       this.reactiveForm = this._fb.group({
          'option1': [this.model.option1, [Validators.required]],

--- a/src/lib/st-select/st-select.component.html
+++ b/src/lib/st-select/st-select.component.html
@@ -22,7 +22,6 @@
          <input [attr.id]="qaTag" type="text" [name]="name" readonly class="st-input-remove-default sth-input-remove-default" [placeholder]="placeholder" [value]="selectedValue && selectedValue.label ? selectedValue.label : ''"
              [disabled]="disabled" (focus)="onFocus($event)" (focusout)="onFocusOut($event)" (blur)="onFocusOut($event)" #input>
          <i class="icon-arrow2_down arrow"></i>
-         <span class="st-input-bar" [ngClass]="getBarType()"></span>
       </div>
    </st-dropdown-menu>
 

--- a/src/lib/st-select/st-select.component.spec.ts
+++ b/src/lib/st-select/st-select.component.spec.ts
@@ -342,13 +342,13 @@ describe('Selects in a form', () => {
    });
 
    it('if it is disabled, label is also displayed as disabled', () => {
-      component.form.controls['modelField'].disable();
+      component.form.controls.modelField.disable();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('label').classList).toContain('disabled');
       expect(fixture.nativeElement.querySelector('.st-input-container').classList).toContain('disabled');
 
-      component.form.controls['modelField'].enable();
+      component.form.controls.modelField.enable();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('label').classList).not.toContain('disabled');

--- a/src/lib/st-select/st-select.component.spec.ts
+++ b/src/lib/st-select/st-select.component.spec.ts
@@ -8,29 +8,30 @@
  *
  * SPDX-License-Identifier: Apache-2.0.
  */
-import { Component, DebugElement, SimpleChanges, SimpleChange } from '@angular/core';
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { FormControl, FormsModule, NgControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Component, SimpleChanges, SimpleChange, ViewChild } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormsModule, ReactiveFormsModule, Validators, FormGroup } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { StLabelModule } from '../st-label/st-label.module';
 import { StDropdownMenuModule } from '../st-dropdown-menu/st-dropdown-menu.module';
-import { StSelectComponent } from './st-select.component';
 
 import { StDropDownMenuItem } from '../st-dropdown-menu/st-dropdown-menu.interface';
+import { StSelectComponent } from './st-select.component';
 
 let comboInput: HTMLInputElement;
 let options: StDropDownMenuItem[] = [
-   { label: 'label1', value: 'value1' },
-   { label: 'label2', value: 'value2' },
-   { label: 'label3', value: 'value3' },
-   { label: 'label4', value: 'value4' },
-   { label: 'label5', value: 'value5' },
-   { label: 'label6', value: 'value6' },
-   { label: 'label7', value: 'value7' },
-   { label: 'label8', value: 'value8' },
-   { label: 'label9', value: 'value9' },
-   { label: 'label10', value: 'value10' }
+   {label: 'Select an option', value: undefined},
+   {label: 'label1', value: 'value1'},
+   {label: 'label2', value: 'value2'},
+   {label: 'label3', value: 'value3'},
+   {label: 'label4', value: 'value4'},
+   {label: 'label5', value: 'value5'},
+   {label: 'label6', value: 'value6'},
+   {label: 'label7', value: 'value7'},
+   {label: 'label8', value: 'value8'},
+   {label: 'label9', value: 'value9'},
+   {label: 'label10', value: 'value10'}
 ];
 
 describe('StSelect', () => {
@@ -38,7 +39,6 @@ describe('StSelect', () => {
    let component: StSelectComponent;
    let fixture: ComponentFixture<StSelectComponent>;
    let compiled: any;
-   let de: DebugElement;
 
    beforeEach(async(() => {
       TestBed.configureTestingModule({
@@ -53,7 +53,6 @@ describe('StSelect', () => {
       comboInput = fixture.debugElement.query(By.css('input')).nativeElement;
       component = fixture.componentInstance;
       compiled = fixture.debugElement.nativeElement;
-
    });
 
    it('st-select should have a placeholder', () => {
@@ -63,7 +62,7 @@ describe('StSelect', () => {
       expect(comboInput.placeholder).toEqual(placeholder);
    });
 
-   it('st-select should be init with options', () => {
+   it('st-select should be initialized with options', () => {
       component.options = options;
       fixture.detectChanges();
       expect(component.hasOptions()).toBeTruthy();
@@ -75,7 +74,7 @@ describe('StSelect', () => {
       expect(component.options).toEqual([]);
    });
 
-   it('st-select should change disabled status', () => {
+   it('st-select should change to disabled status', () => {
       fixture.detectChanges();
       expect(component.disabled).toBeFalsy();
 
@@ -88,12 +87,14 @@ describe('StSelect', () => {
       expect(component.disabled).toBeFalsy();
    });
 
-   it('st-select should change value when come from outside', () => {
+   it('st-select should change its value when it comes from outside', () => {
+      component.options = options;
       fixture.detectChanges();
       expect(component.selectedValue).toBeUndefined();
 
-      component.writeValue(options[2]);
+      component.writeValue(options[2].value);
       fixture.detectChanges();
+
       expect(component.selectedValue).toBeDefined();
       expect(component.selectedValue).toEqual(options[2]);
    });
@@ -107,6 +108,7 @@ describe('StSelect', () => {
       component.registerOnChange(fakeFunction);
       component.onChange(options[1]);
       fixture.detectChanges();
+
       expect(fakeFunction).toHaveBeenCalled();
       expect(fakeFunction).toHaveBeenCalledWith(options[1]);
    });
@@ -120,47 +122,39 @@ describe('StSelect', () => {
       component.registerOnTouched(fakeFunction);
       component.onTouched();
       fixture.detectChanges();
+
       expect(fakeFunction).toHaveBeenCalled();
    });
 
-   it('st-select should write value when update forceValidations input', () => {
+   it('st-select should update its value when forceValidations input is true', () => {
       spyOn(component, 'writeValue').and.callThrough();
       fixture.detectChanges();
       expect(component.writeValue).not.toHaveBeenCalled();
 
-      let changeOther: SimpleChanges = { 'options': new SimpleChange([], [], true) };
+      let changeOther: SimpleChanges = {'options': new SimpleChange([], [], true)};
       component.ngOnChanges(changeOther);
       fixture.detectChanges();
       expect(component.writeValue).not.toHaveBeenCalled();
 
-      let change: SimpleChanges = { 'forceValidations': new SimpleChange(false, true, true) };
+      let change: SimpleChanges = {'forceValidations': new SimpleChange(false, true, true)};
       component.ngOnChanges(change);
       fixture.detectChanges();
       expect(component.writeValue).toHaveBeenCalled();
    });
 
-   it('st-select should change option and notify', () => {
+   it('st-select should change the selected option and notify it', () => {
+      let fakeOnChangeFunction: (_: any) => void = jasmine.createSpy('fake');
+      let fakeOnTouchedFunction: () => void = jasmine.createSpy('fake');
+      component.registerOnChange(fakeOnChangeFunction);
+      component.registerOnTouched(fakeOnTouchedFunction);
       component.options = options;
-      fixture.detectChanges();
-
-      let fakeOnChange: (_: any) => void = jasmine.createSpy('fakeOnChange');
-      let fakeOnTouched: () => void = jasmine.createSpy('fakeOnTouched');
-
-      component.registerOnChange(fakeOnChange);
-      component.registerOnTouched(fakeOnTouched);
-      fixture.detectChanges();
-
-      expect(component.selectedValue).toBeUndefined();
-      expect(component.onChange).not.toHaveBeenCalled();
-      expect(component.onTouched).not.toHaveBeenCalled();
-
       component.changeOption(options[2]);
       fixture.detectChanges();
 
       expect(component.selectedValue).toBeDefined();
       expect(component.selectedValue).toEqual(options[2]);
       expect(component.onChange).toHaveBeenCalled();
-      expect(component.onChange).toHaveBeenCalledWith(options[2]);
+      expect(component.onChange).toHaveBeenCalledWith(options[2].value);
       expect(component.onTouched).toHaveBeenCalled();
    });
 
@@ -218,15 +212,6 @@ describe('StSelect', () => {
       expect(component.showError()).toBeFalsy();
    });
 
-   it('st-select should change classes when error', () => {
-      fixture.detectChanges();
-      expect(component.getBarType()).toEqual('st-input-normal-bar sth-input-normal-bar');
-
-      component.errorMessage = 'error';
-      component.forceValidations = true;
-      fixture.detectChanges();
-      expect(component.getBarType()).toEqual('st-input-error-bar sth-input-error-bar');
-   });
 
    it('st-select should focus input', () => {
       component.errorMessage = 'error';
@@ -247,55 +232,32 @@ describe('StSelect', () => {
       let control: FormControl = new FormControl(undefined, [Validators.required]);
       component.selectedValue = options[2];
       component.forceValidations = true;
-      control.setValue(options[2]);
+      control.setValue(options[2].value);
 
       fixture.detectChanges();
 
       component.validate(control);
       expect(component.showError()).toBeFalsy();
 
-      // Third if in checkValidations
       control.setValue(undefined);
-      fixture.detectChanges();
-      component.validate(control);
-      expect(component.showError()).toBeTruthy();
-
-      // Second if in checkValidations
-      control.setValue({ value: 'value' });
-      fixture.detectChanges();
-      component.validate(control);
-      expect(component.showError()).toBeTruthy();
-
-      control.setValue({ label: 'test' });
-      fixture.detectChanges();
-      component.validate(control);
-      expect(component.showError()).toBeTruthy();
-
-      control.setValue('test');
-      fixture.detectChanges();
-      component.validate(control);
-      expect(component.showError()).toBeTruthy();
-
-      // First if in checkValidations
-      control.setValue({});
       fixture.detectChanges();
       component.validate(control);
       expect(component.showError()).toBeTruthy();
    });
 
    it('st-select should validate with custom message', () => {
-      let control: FormControl = new FormControl();
+      let control: FormControl = new FormControl('', [Validators.required]);
       component.selectedValue = options[2];
       component.forceValidations = true;
       component.errorRequiredMessage = 'This field is required';
-      control.setValue(options[2]);
+      control.setValue(options[2].value);
 
       fixture.detectChanges();
       component.validate(control);
       expect(component.showError()).toBeFalsy();
 
-      control.setValue(options[2]);
-      control.setErrors({ 'required': true });
+      control.setValue(options[2].value);
+      control.setErrors({'required': true});
       fixture.detectChanges();
       component.validate(control);
       expect(component.showError()).toBeTruthy();
@@ -305,14 +267,14 @@ describe('StSelect', () => {
       component.validate(control);
       expect(component.showError()).toBeTruthy();
 
-      control.setValue(options[2]);
-      control.setErrors({ 'custom': true });
+      control.setValue(options[2].value);
+      control.setErrors({'custom': true});
       fixture.detectChanges();
       component.validate(control);
       expect(component.showError()).toBeTruthy();
 
       control.setValue(undefined);
-      control.setErrors({ 'required': true });
+      control.setErrors({'required': true});
       fixture.detectChanges();
       component.validate(control);
       expect(component.showError()).toBeTruthy();
@@ -320,7 +282,76 @@ describe('StSelect', () => {
 
 });
 
+describe('Selects in a form', () => {
+   @Component({
+      template: `
+  <form [formGroup]="form" novalidate>
+      <st-select
+            [options]="options"
+            label="Model field" name="modelField"
+            contextualHelp="Select option from list"
+            [errorRequiredMessage]="errorMessage"
+            placeholder="Select option"
+            formControlName="modelField"
+      ></st-select>
+   </form>`
+   })
 
+   class TestStSelectComponent {
+      public form: FormGroup;
+      public options: StDropDownMenuItem[];
+      public control: FormControl = new FormControl(options[1].value, [Validators.required]);
+      public errorMessage: string = 'Error, this field is required';
 
+      @ViewChild(StSelectComponent) select: StSelectComponent;
 
+      constructor() {
+         this.form = new FormGroup({
+            modelField: this.control
+         });
+         this.options = options;
+      }
+   }
 
+   let component: TestStSelectComponent;
+   let fixture: ComponentFixture<TestStSelectComponent>;
+   let select: StSelectComponent;
+
+   beforeEach(async(() => {
+      TestBed.configureTestingModule({
+         imports: [FormsModule, ReactiveFormsModule, StLabelModule, StDropdownMenuModule],
+         declarations: [TestStSelectComponent, StSelectComponent]
+      })
+         .compileComponents();  // compile template and css
+   }));
+
+   beforeEach(() => {
+      fixture = TestBed.createComponent(TestStSelectComponent);
+      component = fixture.componentInstance;
+      select = component.select;
+      fixture.detectChanges();
+   });
+
+   it('when there is a validation error, it should display the error message and change the label and input class', () => {
+      select.changeOption(options[0]);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('label').classList).toContain('error');
+      expect(fixture.nativeElement.querySelector('.st-input-container').classList).toContain('error');
+      expect(fixture.nativeElement.querySelector('.st-input-error-message').innerHTML).toBe(component.errorMessage);
+   });
+
+   it('if it is disabled, label is also displayed as disabled', () => {
+      component.form.controls['modelField'].disable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('label').classList).toContain('disabled');
+      expect(fixture.nativeElement.querySelector('.st-input-container').classList).toContain('disabled');
+
+      component.form.controls['modelField'].enable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('label').classList).not.toContain('disabled');
+      expect(fixture.nativeElement.querySelector('.st-input-container').classList).not.toContain('disabled');
+   });
+});

--- a/src/lib/st-select/st-select.component.ts
+++ b/src/lib/st-select/st-select.component.ts
@@ -13,13 +13,10 @@ import {
    ChangeDetectorRef,
    Component,
    ElementRef,
-   EventEmitter,
    forwardRef,
    Input,
    OnChanges,
-   Output,
    Renderer,
-   SimpleChange,
    SimpleChanges,
    ViewChild,
    OnDestroy
@@ -29,7 +26,8 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { EventWindowManager } from '../utils/event-window-manager';
 import { StDropDownMenuItem } from '../st-dropdown-menu/st-dropdown-menu.interface';
-import { StEgeo, StRequired } from '../decorators/require-decorators';
+import { StEgeo } from '../decorators/require-decorators';
+import { StFormLabelStatus } from '../utils/egeo-form/st-form-label/st-form-label-status.enum';
 
 @StEgeo()
 @Component({
@@ -86,7 +84,7 @@ export class StSelectComponent extends EventWindowManager implements ControlValu
 
    // Write a new value to the element.
    writeValue(newValue: any): void {
-      this.selectedValue = newValue;
+      this.selectedValue = this.options.find(option => option.value === newValue);
    }
 
    // Set the function to be called when the control receives a change event.
@@ -118,7 +116,7 @@ export class StSelectComponent extends EventWindowManager implements ControlValu
 
    changeOption(selection: StDropDownMenuItem): void {
       this.selectedValue = selection;
-      this.onChange(selection);
+      this.onChange(selection.value);
       this.onTouched();
       this.pristine = false;
       this.closeElement();
@@ -135,11 +133,6 @@ export class StSelectComponent extends EventWindowManager implements ControlValu
       return this.errorMessage !== undefined && (!this.pristine || this.forceValidations) && !this.isFocused && !this.disabled;
    }
 
-   /** Style functions */
-   getBarType(): string {
-      return this.showError() ? 'st-input-error-bar sth-input-error-bar' : 'st-input-normal-bar sth-input-normal-bar';
-   }
-
    onFocus(event: Event): void {
       this.isFocused = true;
    }
@@ -148,35 +141,10 @@ export class StSelectComponent extends EventWindowManager implements ControlValu
       this.isFocused = false;
    }
 
-   private getErrorObject(control: FormControl): { [key: string]: any } {
-      let errors: { [key: string]: any };
-      if (control.errors) {
-         errors = this.checkValidations(control) ? Object.assign({}, control.errors, { 'OptionRequired': true }) : control.errors;
-      } else {
-         errors = this.checkValidations(control) ? { 'OptionRequired': true } : undefined;
-      }
-      return errors;
-   }
-
-   private checkValidations(control: FormControl): boolean {
-      if (!control || !this.isDefined(control.value) || control.value === {}) {
-         return true;
-      }
-      if (typeof control.value !== 'object' || !this.isDefined(control.value.value) || !this.isDefined(control.value.label)) {
-         return true;
-      }
-      return false;
-   }
-
-   private isDefined(field: any): boolean {
-      return field !== undefined && field !== null;
-   }
-
    // When status change call this function to check if have errors
    private checkErrors(control: FormControl): void {
       this.pristine = control.pristine;
-      let errors: { [key: string]: any } = this.getErrorObject(control);
-      this.errorMessage = this.getErrorMessage(errors);
+      this.errorMessage = this.getErrorMessage(control.errors);
       this.cd.markForCheck();
    }
 
@@ -191,10 +159,6 @@ export class StSelectComponent extends EventWindowManager implements ControlValu
       }
 
       if (errors.hasOwnProperty('required')) {
-         return this.errorRequiredMessage;
-      }
-
-      if (errors.hasOwnProperty('OptionRequired')) {
          return this.errorRequiredMessage;
       }
 

--- a/src/lib/st-select/st-select.component.ts
+++ b/src/lib/st-select/st-select.component.ts
@@ -26,10 +26,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { EventWindowManager } from '../utils/event-window-manager';
 import { StDropDownMenuItem } from '../st-dropdown-menu/st-dropdown-menu.interface';
-import { StEgeo } from '../decorators/require-decorators';
-import { StFormLabelStatus } from '../utils/egeo-form/st-form-label/st-form-label-status.enum';
 
-@StEgeo()
 @Component({
    selector: 'st-select',
    templateUrl: './st-select.component.html',


### PR DESCRIPTION
Closes #CCT-144
### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [x] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage