### PR TITLE
fix(st-breadcrumbs)[CCT-502]: Remove left padding from the first item and right padding from the last one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * st-modal: Removed space when modal does not have buttons
 * st-modal: Reorder buttons in delete confirmation modal
+* st-breadcrumbs: Remove left padding from the first item and right padding to the last one
 
 **New features:**
 

--- a/src/lib/st-alerts/alert-box/st-alert-box.component.spec.ts
+++ b/src/lib/st-alerts/alert-box/st-alert-box.component.spec.ts
@@ -33,7 +33,7 @@ describe('StAlertsComponent', () => {
          component = fixture.componentInstance;
       });
 
-      it('Should be init correctly', fakeAsync(() => {
+      it('Should be initialized correctly', fakeAsync(() => {
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, undefined);
          component.showInConsole = false;
          fixture.detectChanges();
@@ -44,7 +44,7 @@ describe('StAlertsComponent', () => {
          discardPeriodicTasks();
       }));
 
-      it('Should be return correct icon', () => {
+      it('Should return correct icon', () => {
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, undefined);
          component.showInConsole = false;
          fixture.detectChanges();
@@ -61,7 +61,7 @@ describe('StAlertsComponent', () => {
          expect(component.getIcon()).toEqual('');
       });
 
-      it('Should be return correct color by severity', () => {
+      it('Should return correct color by severity', () => {
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, undefined);
          component.showInConsole = false;
          fixture.detectChanges();
@@ -78,7 +78,7 @@ describe('StAlertsComponent', () => {
          expect(component.getSeverityColor()).toEqual('');
       });
 
-      it('Should be go to link', () => {
+      it('Should go to link', () => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, link);
          component.showInConsole = false;
@@ -92,7 +92,7 @@ describe('StAlertsComponent', () => {
          expect(window.open).toHaveBeenCalledWith(link.link);
       });
 
-      it('Should be notify in console error', () => {
+      it('Should notify in console error', () => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, link);
          component.showInConsole = true;
@@ -107,7 +107,7 @@ describe('StAlertsComponent', () => {
          expect(console.error).toHaveBeenCalledWith(`ERROR-${component.alert.title}: ${component.alert.message}`);
       });
 
-      it('Should be notify in console warning', () => {
+      it('Should notify in console warning', () => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.WARNING, 1000, 500, link);
          component.showInConsole = true;
@@ -122,7 +122,7 @@ describe('StAlertsComponent', () => {
          expect(console.warn).toHaveBeenCalledWith(`WARNING-${component.alert.title}: ${component.alert.message}`);
       });
 
-      it('Should be notify in console info', () => {
+      it('Should notify in console info', () => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.SUCCESS, 1000, 500, link);
          component.showInConsole = true;
@@ -137,7 +137,7 @@ describe('StAlertsComponent', () => {
          expect(console.log).toHaveBeenCalledWith(`SUCCESS-${component.alert.title}: ${component.alert.message}`);
       });
 
-      it('Should be notify in console error by default if not found severity', () => {
+      it('Should notify in console error by default if not found severity', () => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', undefined, 1000, 500, link);
          component.showInConsole = true;
@@ -152,7 +152,7 @@ describe('StAlertsComponent', () => {
          expect(console.error).toHaveBeenCalledWith(`ERROR: severity not found for ${component.alert.title}: ${component.alert.message}`);
       });
 
-      it('Should be notify pause alert', fakeAsync(() => {
+      it('Should notify pause alert', fakeAsync(() => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, link);
          spyOn(component.alert, 'pauseNotify').and.callThrough();
@@ -172,7 +172,7 @@ describe('StAlertsComponent', () => {
          discardPeriodicTasks();
       }));
 
-      it('Should be notify continue alert after pause', fakeAsync(() => {
+      it('Should notify continue alert after pause', fakeAsync(() => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, link);
          spyOn(component.alert, 'pauseNotify').and.callThrough();
@@ -200,7 +200,7 @@ describe('StAlertsComponent', () => {
          discardPeriodicTasks();
       }));
 
-      it('Should be notify close alert', fakeAsync(() => {
+      it('Should notify close alert', fakeAsync(() => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, link);
          spyOn(component.alert, 'cancel').and.callThrough();
@@ -222,7 +222,7 @@ describe('StAlertsComponent', () => {
          discardPeriodicTasks();
       }));
 
-      it('Should be fade out alert after life time', fakeAsync(() => {
+      it('Should fade out alert after life time', fakeAsync(() => {
          let link: StAlertLink = { link: 'test', title: 'test title' };
          component.alert = new StAlert(0, 'Error', 'error message', STALERT_SEVERITY.ERROR, 1000, 500, link);
          fixture.detectChanges();

--- a/src/lib/st-breadcrumbs/st-breadcrumbs.component.html
+++ b/src/lib/st-breadcrumbs/st-breadcrumbs.component.html
@@ -13,7 +13,7 @@
 <ul class="st-breadcrumbs" [attr.id]="qaTag">
    <ng-content select="st-breadcrumbs-item"></ng-content>
    <div *ngIf="options.length">
-      <st-breadcrumbs-item *ngFor="let idx of indexArray; let last=last" (click)="onSelect(idx)" [active]="last"
+      <st-breadcrumbs-item class ="sth-breadcrumbs__item-container" *ngFor="let idx of indexArray; let last=last" (click)="onSelect(idx)" [active]="last"
          [qaTag]="qaTag + '-' + idx">{{getOption(idx)}}</st-breadcrumbs-item>
    </div>
 </ul>

--- a/src/lib/st-select/st-check-validations.ts
+++ b/src/lib/st-select/st-check-validations.ts
@@ -39,7 +39,6 @@ export class StCheckValidationsDirective implements OnInit, OnDestroy {
 
    // TODO implement error check and notify correct error
    private notifyErrorsIfExists(): void {
-      console.log(this.control.errors);
       if (this.control.valid && this.onChange) {
          this.onChange(null);
       } else if (this.onChange) {

--- a/src/theme/components/_breadcrumbs.scss
+++ b/src/theme/components/_breadcrumbs.scss
@@ -19,10 +19,10 @@
       text-transform: capitalize;
 
       &:after {
-        font-family: $egeo-stratio-icons;
-        content: "\E605";
-        font-size: $egeo-font-size-xxxsmall;
-        color: $neutral-10;
+         font-family: $egeo-stratio-icons;
+         content: "\E605";
+         font-size: $egeo-font-size-xxxsmall;
+         color: $neutral-10;
       }
 
       &--text {
@@ -36,11 +36,21 @@
       .last & {
          &--text {
             color: $neutral-13;
+            padding-right: 0;
          }
       }
 
       &.last:after {
-        content: "";
+         content: "";
       }
    }
+
+   &__item-container:first-child {
+      .sth-breadcrumbs__item--text {
+         padding-left: 0;
+      }
+   }
+
 }
+
+


### PR DESCRIPTION
### Documentation
- [ ] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [ ] Have example running in demo app
- [x] Review id on demo is the same of egeo folder

### Code
- [x] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage