### PR TITLE
feat(st-tag-input)[UX-7]: Add functionality to not allow user to type forbidden values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 **New features:**
 
 * st-search: Add filter to search
-* st-tag-input: Add functionality to not allow user to type forbidden values
 * st-widget: Add settings button and draggable action as optional
 * st-tag-input: Add functionality to not allow user to type forbidden values
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 **New features:**
 
 * st-search: Add filter to search
+* st-tag-input: Add functionality to not allow user to type forbidden values
 * st-widget: Add settings button and draggable action as optional
+* st-tag-input: Add functionality to not allow user to type forbidden values
 
 **Breaking changes:**
 

--- a/src/egeo-demo/st-tag-input-demo/st-tag-input-demo.component.html
+++ b/src/egeo-demo/st-tag-input-demo/st-tag-input-demo.component.html
@@ -21,8 +21,11 @@
       [label]="'Tag Input'"
       [id]="'tag-input-reactive-demo'"
       [placeholder]="'Add tags separated by commas'"
-      [tooltip]="'This is a Tag Input component tooltip'">
+      [tooltip]="'This is a Tag Input component tooltip'"
+      [forbiddenValues]="['test']">
    </st-tag-input>
+
+   Forbidden values: test
 
    <div class="separator"></div>
 
@@ -115,7 +118,7 @@
       [placeholder]="'Add tags separated by commas'"
       [tooltip]="'This is a Tag Input component tooltip'">
    </st-tag-input>
-    
+
    <div class="separator"></div>
 
    <st-tag-input

--- a/src/lib/st-tag-input/README.md
+++ b/src/lib/st-tag-input/README.md
@@ -1,0 +1,48 @@
+# {TITLE} (Component)
+
+   Tag InputThis component is a text input box that automatically creates tags out of a typed text.
+
+## Inputs
+
+| Property         | Type               | Req   | Description                                                                                                           | Default |
+| ---------------- | ------------------ | ----- | --------------------------------------------------------------------------------------------------------------------- | ------- |
+| label            | String \| null     | False | Label to show over the input. It is empty by default                                                                  | null    |
+| tooltip          | String \| null     | False | The tooltip to show  over the label. It is empty by default                                                           | null    |
+| placeholder      | String \| null     | False | The text that appears as placeholder of the input. It is empty by default                                             | null    |
+| errorMessage     | String \| null     | False | Error message to show. It is empty by default                                                                         | null    |
+| withAutocomplete | Boolean            | False | Enable autocomplete feature. It is false by default                                                                   | false   |
+| autocompleteList | StDropDownMenuItem | False | List to be used for autocomplete feature. It is empty by default                                                      | Array() |
+| forbiddenValues  | String[]           | False | A list of values that user can not type and if he types one of them,tag input will be invalid. It is empty by default | Array() |
+| disabled         | Boolean            | False | Disable the component. It is false by default                                                                         | false   |
+
+## Example
+
+
+```html
+<st-tag-input class="st-form-field"
+      name="tag-input-reactive"
+      formControlName="tag-input-reactive"
+      [autocompleteList]="filteredlist"
+      [withAutocomplete]="true"
+      [disabled]="disabled"
+      [label]="'Tag Input with Reactive Form'"
+      [id]="'tag-input-reactive'"
+      [placeholder]="'Add tags separated by commas'"
+      [tooltip]="'This is a Tag Input component tooltip'"
+      [forbiddenValues]="['test']"
+      (input)="onFilterList($event)">
+</st-tag-input>
+<st-tag-input class="st-form-field"
+      name="tag-input-template-driven"
+      [(ngModel)]="tags.templateDriven"
+      [autocompleteList]="filteredlist"
+      [withAutocomplete]="true"
+      [disabled]="disabled"
+      [label]="'Tag Input with Template Driven Form'"
+      [id]="'tag-input-template-driven'"
+      [placeholder]="'Add tags separated by commas'"
+      [tooltip]="'This is a Tag Input component tooltip'"
+      (input)="onFilterList($event)">
+</st-tag-input>
+```
+

--- a/src/lib/st-tag-input/st-tag-input.component.spec.ts
+++ b/src/lib/st-tag-input/st-tag-input.component.spec.ts
@@ -527,6 +527,7 @@ describe('StTagInputComponent', () => {
          fixture = TestBed.createComponent(StTagInputTestReactiveComponent);
          comp = fixture.componentInstance;
          compTagInput = comp.tagInput;
+         fixture.detectChanges();
       });
 
       afterEach(() => {
@@ -680,5 +681,41 @@ describe('StTagInputComponent', () => {
             expect(comp.templateDrivenForm.valid).toBeTruthy();
          });
       }));
+
+      describe('should be able to not allow user types a forbidden value if there are', () => {
+         it('if a forbidden value list is not introduced as input, user can introduce whatever he wants', () => {
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => { // Form generation it's asynchronous
+               comp.templateDrivenForm.form.get('tags').setValue(['New Tag']);
+               fixture.detectChanges();
+
+               expect(comp.templateDrivenForm.valid).toBeTruthy();
+
+               comp.templateDrivenForm.form.get('tags').setValue(['New value 2']);
+               fixture.detectChanges();
+
+               expect(comp.templateDrivenForm.valid).toBeTruthy();
+            });
+         });
+
+         it('if a forbidden value list is introduced as input and user introduces a forbidden value, form control will be invalid', () => {
+            compTagInput.forbiddenValues = ['forbidden value'];
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => { // Form generation it's asynchronous
+               comp.templateDrivenForm.form.get('tags').setValue(['New Tag']);
+               fixture.detectChanges();
+
+               expect(comp.templateDrivenForm.valid).toBeTruthy();
+
+               comp.templateDrivenForm.form.get('tags').setValue(['forbidden value']);
+               fixture.detectChanges();
+
+               expect(comp.templateDrivenForm.valid).toBeFalsy();
+            });
+         });
+      });
+
    });
 });

--- a/src/lib/st-tag-input/st-tag-input.component.ts
+++ b/src/lib/st-tag-input/st-tag-input.component.ts
@@ -54,6 +54,7 @@ import { StDropDownMenuItem } from '../st-dropdown-menu/st-dropdown-menu.interfa
  *    [id]="'tag-input-reactive'"
  *    [placeholder]="'Add tags separated by commas'"
  *    [tooltip]="'This is a Tag Input component tooltip'"
+ *    [forbiddenValues]="['test']"
  *    (input)="onFilterList($event)">
  * </st-tag-input>
  * <st-tag-input
@@ -96,8 +97,13 @@ export class StTagInputComponent implements ControlValueAccessor, Validator, OnI
 
    /** @input {boolean} [withAutocomplete=false] Enable autocomplete feature. It is false by default */
    @Input() withAutocomplete: boolean = false;
-   /** @input {StDropDownMenuItem} [autocompleteList=[]] List to be used for autocomplete feature. It is empty by default */
+   /** @input {StDropDownMenuItem} [autocompleteList=Array()] List to be used for autocomplete feature. It is empty by default */
    @Input() autocompleteList: StDropDownMenuItem[] = [];
+
+   /** @input {string[]} [forbiddenValues=Array()] A list of values that user can not type and if he types one of them,
+    * tag input will be invalid. It is empty by default
+    */
+   @Input() forbiddenValues: string[] = [];
 
    @ViewChild('newElement') newElementInput: ElementRef;
    @ViewChild('inputElement') inputElement: ElementRef;
@@ -108,7 +114,7 @@ export class StTagInputComponent implements ControlValueAccessor, Validator, OnI
 
    private _focus: boolean = false;
    private _isDisabled: boolean = false;
-   private _newElementInput: HTMLElement | null = null;
+   private _newElementInput: HTMLInputElement | null = null;
    private _selected: number | null = null;
 
    onChange = (_: any) => { };
@@ -151,7 +157,9 @@ export class StTagInputComponent implements ControlValueAccessor, Validator, OnI
    }
 
    get isValidInput(): boolean {
-      return this.innerInputContent.length ? this.items.indexOf(this.innerInputContent) === -1 : true;
+      const isForbidden = this.forbiddenValues.length && this.forbiddenValues.indexOf(this.innerInputContent) > -1;
+      const isDuplicated = this.items.indexOf(this.innerInputContent) !== -1;
+      return this.innerInputContent.length ? !isForbidden && !isDuplicated : true;
    }
 
    get tagSelected(): number | null {


### PR DESCRIPTION
Closes #UX-7

### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [x] Review id on demo is the same of egeo folder

### Code
- [x] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage