### PR TITLE
fix(st-input)[UX-29]: Add a gray color to input text when it is disabled and it has value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * st-tag-input: Add functionality to not allow user to type values with invalid format
 
+**Fixed bugs:**
+
+* st-input: Add a gray color to text when it is disabled and it has value
 
 ## 8.0.0 (January 24, 2018)
 

--- a/src/egeo-demo/st-input-demo/st-input-demo.html
+++ b/src/egeo-demo/st-input-demo/st-input-demo.html
@@ -13,22 +13,34 @@
 
 
 <h1>Without form control</h1>
-<st-input type="text" name="Name" placeholder="Enter your name" value="Peter"  label="Name"></st-input>
+<st-input class="st-form-field" type="text" name="Name" placeholder="Enter your name" value="Peter"
+          label="Name"></st-input>
 
 <br>
 
 <h1>Inside form</h1>
 
 <form [formGroup]="myForm" novalidate>
-   <st-input type="text" formControlName="name" placeholder="Enter your name" label="Field" contextualHelp="This is a normal field"></st-input>
-   <st-input type="text" formControlName="disabledField" placeholder="This field is disabled" label="Disabled field"></st-input>
-   <st-input type="text" formControlName="requiredField" placeholder="This field is required" [errors]="requiredError" label="Required field" contextualHelp="This is a required field"></st-input>
-   <label class ="st-label">Native Input with st-input class</label>
-   <input class ="st-input"  formControlName="requiredField"  placeholder="This field is created with st-input class"/>
-   <label class ="st-label">Native disabled Input with class</label>
-   <input class ="st-input"  formControlName="disabledField"  placeholder="This field is disabled"/>
+   <st-input class="st-form-field" type="text" formControlName="name" placeholder="Enter your name" label="Field"
+             contextualHelp="This is a normal field"></st-input>
+   <st-input class="st-form-field" type="text" formControlName="disabledField" placeholder="This field is disabled"
+             label="Disabled field"></st-input>
+   <st-input class="st-form-field" type="text" formControlName="disabledFieldWithValue"
+             placeholder="This field is disabled" label="Disabled field"></st-input>
+
+   <st-input class="st-form-field" type="text" formControlName="requiredField" placeholder="This field is required"
+             [errors]="requiredError" label="Required field" contextualHelp="This is a required field"></st-input>
+   <div class="st-form-field">
+      <label class="st-label">Native Input with st-input class</label>
+      <input class="st-input st-form-field" formControlName="requiredField"
+             placeholder="This field is created with st-input class"/>
+   </div>
+   <div class="st-form-field">
+      <label class="st-label">Native disabled Input with class</label>
+      <input class="st-input st-form-field" formControlName="disabledField" placeholder="This field is disabled"/>
+   </div>
 </form>
 
-<button  class="button button-primary" (click)="disableInput()">DISABLE/ENABLE INPUTS</button>
+<button class="button button-primary" (click)="disableInput()">DISABLE/ENABLE INPUTS</button>
 
 

--- a/src/egeo-demo/st-input-demo/st-input-demo.ts
+++ b/src/egeo-demo/st-input-demo/st-input-demo.ts
@@ -26,9 +26,12 @@ export class StInputDemoComponent {
       this.myForm = fb.group({
          name: new FormControl('', []),
          disabledField: new FormControl('', []),
+         disabledFieldWithValue:  new FormControl('Disabled value', []),
          requiredField: new FormControl('', [Validators.required])
       });
       this.myForm.controls.disabledField.disable();
+      this.myForm.controls.disabledFieldWithValue.disable();
+
       this.myForm.valueChanges.subscribe(res => console.log(res));
    }
 
@@ -38,10 +41,12 @@ export class StInputDemoComponent {
       if (this.disabled) {
          this.myForm.controls.name.disable();
          this.myForm.controls.disabledField.disable();
+         this.myForm.controls.disabledFieldWithValue.disable();
          this.myForm.controls.requiredField.disable();
       } else {
          this.myForm.controls.name.enable();
          this.myForm.controls.disabledField.enable();
+         this.myForm.controls.disabledFieldWithValue.enable();
          this.myForm.controls.requiredField.enable();
 
       }

--- a/src/theme/utils/_forms.scss
+++ b/src/theme/utils/_forms.scss
@@ -40,6 +40,7 @@
 
    &:disabled {
       border-color: $neutral-05;
+      color: $neutral-05;
 
       &::placeholder {
          color: $neutral-05;


### PR DESCRIPTION
Closes #UX-29 

### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage