### PR TITLE
feat(st-tag-input)[UX-17]: Add functionality to not allow user to type values with invalid format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## 9.0.0 (upcoming)
+## 8.1.0 (upcoming)
 
-* Pending changelog
+**New features:**
+
+* st-tag-input: Add functionality to not allow user to type values with invalid format
+
 
 ## 8.0.0 (January 24, 2018)
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
    <groupId>com.stratio.egeo</groupId>
    <artifactId>egeo</artifactId>
-   <version>9.0.0-SNAPSHOT</version>
+   <version>8.1.0-SNAPSHOT</version>
    <name>Egeo</name>
    <inceptionYear>2016</inceptionYear>
 

--- a/src/egeo-demo/st-tag-input-demo/st-tag-input-demo.component.html
+++ b/src/egeo-demo/st-tag-input-demo/st-tag-input-demo.component.html
@@ -14,6 +14,7 @@
 <h1>MODEL DRIVEN / REACTIVE EXAMPLE</h1>
 <form [formGroup]="reactiveForm" novalidate (ngSubmit)="onSubmitReactiveForm()">
 
+   <h1> With forbidden values </h1>
    <st-tag-input
       class="st-form-field"
       name="tag-input-reactive"
@@ -29,10 +30,13 @@
 
    <div class="separator"></div>
 
+   <h1> With value pattern </h1>
+
    <st-tag-input
       class="st-form-field"
       name="tag-input-reactive-required"
       formControlName="tag-input-reactive-required"
+      [regularExpression]="pattern"
       [errorMessage]="errorReactiveMessage"
       [label]="'Tag Input with require'"
       [id]="'tag-input-reactive-required-demo'"
@@ -71,7 +75,7 @@
    <div class="separator"></div>
 
    <button type="submit" class="button button-primary"><span>Validate</span></button>
-   <button type="button" class="button button-secondary-gray" (click)="changetReactiveFormDisabled()"><span>Disable</span></button>
+   <button type="button" class="button button-secondary-gray" (click)="changeReactiveFormDisabled()"><span>Disable</span></button>
 
 </form>
 

--- a/src/egeo-demo/st-tag-input-demo/st-tag-input-demo.component.ts
+++ b/src/egeo-demo/st-tag-input-demo/st-tag-input-demo.component.ts
@@ -57,6 +57,7 @@ export class StTagInputDemoComponent implements OnInit {
    public errorTemplateDriveMessage: string | null = null;
    public disabledReactive: boolean = true;
    public disabledTemplateDrive: boolean = true;
+   public pattern: any =  /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
    constructor(private _fb: FormBuilder) {
       this.reactiveForm = _fb.group({
@@ -82,7 +83,7 @@ export class StTagInputDemoComponent implements OnInit {
       this.errorTemplateDriveMessage = this.templateDrivenForm.valid ? null : 'Error';
    }
 
-   changetReactiveFormDisabled(): void {
+   changeReactiveFormDisabled(): void {
       this.disabledReactive = !this.disabledReactive;
       if (this.disabledReactive) {
          this.reactiveForm.get('tag-input-reactive-disabled').disable();

--- a/src/lib/st-tag-input/README.md
+++ b/src/lib/st-tag-input/README.md
@@ -4,16 +4,17 @@
 
 ## Inputs
 
-| Property         | Type               | Req   | Description                                                                                                           | Default |
-| ---------------- | ------------------ | ----- | --------------------------------------------------------------------------------------------------------------------- | ------- |
-| label            | String \| null     | False | Label to show over the input. It is empty by default                                                                  | null    |
-| tooltip          | String \| null     | False | The tooltip to show  over the label. It is empty by default                                                           | null    |
-| placeholder      | String \| null     | False | The text that appears as placeholder of the input. It is empty by default                                             | null    |
-| errorMessage     | String \| null     | False | Error message to show. It is empty by default                                                                         | null    |
-| withAutocomplete | Boolean            | False | Enable autocomplete feature. It is false by default                                                                   | false   |
-| autocompleteList | StDropDownMenuItem | False | List to be used for autocomplete feature. It is empty by default                                                      | Array() |
-| forbiddenValues  | String[]           | False | A list of values that user can not type and if he types one of them,tag input will be invalid. It is empty by default | Array() |
-| disabled         | Boolean            | False | Disable the component. It is false by default                                                                         | false   |
+| Property          | Type               | Req   | Description                                                                                                           | Default |
+| ----------------- | ------------------ | ----- | --------------------------------------------------------------------------------------------------------------------- | ------- |
+| label             | String \| null     | False | Label to show over the input. It is empty by default                                                                  | null    |
+| tooltip           | String \| null     | False | The tooltip to show  over the label. It is empty by default                                                           | null    |
+| placeholder       | String \| null     | False | The text that appears as placeholder of the input. It is empty by default                                             | null    |
+| errorMessage      | String \| null     | False | Error message to show. It is empty by default                                                                         | null    |
+| withAutocomplete  | Boolean            | False | Enable autocomplete feature. It is false by default                                                                   | false   |
+| autocompleteList  | StDropDownMenuItem | False | List to be used for autocomplete feature. It is empty by default                                                      | Array() |
+| forbiddenValues   | String[]           | False | A list of values that user can not type and if he types one of them,tag input will be invalid. It is empty by default | Array() |
+| regularExpression | String             | False | Regular expression to validate values. It is null by default                                                          |         |
+| disabled          | Boolean            | False | Disable the component. It is false by default                                                                         | false   |
 
 ## Example
 
@@ -42,6 +43,7 @@
       [id]="'tag-input-template-driven'"
       [placeholder]="'Add tags separated by commas'"
       [tooltip]="'This is a Tag Input component tooltip'"
+      [regularExpression]="pattern"
       (input)="onFilterList($event)">
 </st-tag-input>
 ```

--- a/src/lib/st-tag-input/st-tag-input.component.html
+++ b/src/lib/st-tag-input/st-tag-input.component.html
@@ -29,7 +29,7 @@
          (focusin)="onInputFocusIn($event)" (focusout)="onInputFocusOut($event)" (blur)="onInputFocusOut($event)"
          (input)="onInputText($event.target.textContent)" (keydown)="onInputKeyDown($event)"></div>
    </div>
- </div>
+</div>
 
 </st-dropdown-menu>
 

--- a/src/lib/st-tag-input/st-tag-input.component.ts
+++ b/src/lib/st-tag-input/st-tag-input.component.ts
@@ -68,6 +68,7 @@ import { StDropDownMenuItem } from '../st-dropdown-menu/st-dropdown-menu.interfa
  *    [id]="'tag-input-template-driven'"
  *    [placeholder]="'Add tags separated by commas'"
  *    [tooltip]="'This is a Tag Input component tooltip'"
+ *    [regularExpression]="pattern"
  *    (input)="onFilterList($event)">
  * </st-tag-input>
  * ```
@@ -104,6 +105,8 @@ export class StTagInputComponent implements ControlValueAccessor, Validator, OnI
     * tag input will be invalid. It is empty by default
     */
    @Input() forbiddenValues: string[] = [];
+   /** @input {string} [regularExpression=] Regular expression to validate values. It is null by default */
+   @Input() regularExpression: any | null = null;
 
    @ViewChild('newElement') newElementInput: ElementRef;
    @ViewChild('inputElement') inputElement: ElementRef;
@@ -159,7 +162,9 @@ export class StTagInputComponent implements ControlValueAccessor, Validator, OnI
    get isValidInput(): boolean {
       const isForbidden = this.forbiddenValues.length && this.forbiddenValues.indexOf(this.innerInputContent) > -1;
       const isDuplicated = this.items.indexOf(this.innerInputContent) !== -1;
-      return this.innerInputContent.length ? !isForbidden && !isDuplicated : true;
+      let regularExp = new RegExp(this.regularExpression);
+      const matchedPattern = this.regularExpression ? regularExp.test(this.innerInputContent) : true;
+      return this.innerInputContent.length ? !isForbidden && !isDuplicated && matchedPattern : true;
    }
 
    get tagSelected(): number | null {


### PR DESCRIPTION
Closes #UX-17

### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [x] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [x] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage