### PR TITLE
fix(st-pagination)[UX-35]: Fix error when a change is listened from outside and remove actions when it is being created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 * Pending changelog
 
+## 8.1.1 (February 02, 2018)
+
+**Fixed bugs:**
+
+* st-pagination: Fix error when a change is listened from outside because. This causes that some inputs are changed after checked
+
+
 ## 8.1.0 (January 31, 2018)
 
 **New features:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,7 @@
 * Pending changelog
 
 
-## 8.0.2 (February 05, 2018)
-
-**Fixed bugs:**
-
-* st-pagination: Do not perform any action when changes are listened when pagination is being created
-
-
 ## 8.1.1 (February 02, 2018)
-
-**Fixed bugs:**
-
-* st-pagination: Fix error when a change is listened from outside because. This causes that some inputs are changed after checked
-
-
-## 8.0.1 (February 02, 2018)
 
 **Fixed bugs:**
 
@@ -35,6 +21,21 @@
 **Fixed bugs:**
 
 * st-input: Add a gray color to text when it is disabled and it has value
+
+
+## 8.0.2 (February 05, 2018)
+
+**Fixed bugs:**
+
+* st-pagination: Do not perform any action when changes are listened when pagination is being created
+
+
+## 8.0.1 (February 02, 2018)
+
+**Fixed bugs:**
+
+* st-pagination: Fix error when a change is listened from outside because. This causes that some inputs are changed after checked
+
 
 ## 8.0.0 (January 24, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@
 
 * Pending changelog
 
+
+## 8.0.2 (February 05, 2018)
+
+**Fixed bugs:**
+
+* st-pagination: Do not perform any action when changes are listened when pagination is being created
+
+
 ## 8.1.1 (February 02, 2018)
+
+**Fixed bugs:**
+
+* st-pagination: Fix error when a change is listened from outside because. This causes that some inputs are changed after checked
+
+
+## 8.0.1 (February 02, 2018)
 
 **Fixed bugs:**
 

--- a/src/lib/st-pagination/st-pagination.component.spec.ts
+++ b/src/lib/st-pagination/st-pagination.component.spec.ts
@@ -261,4 +261,46 @@ describe('StPaginationComponent', () => {
          expect(component.selectedItem.value).toEqual(50);
       });
    });
+
+
+   it('When it listens any change, it only force to update the changed input if it is not its first change', () => {
+      spyOn(component, 'generateItems').and.callThrough();
+      spyOn(component, 'onChangePerPage').and.callThrough();
+
+      component.currentPage = 3;
+      component.total = 3;
+      component.perPage = 3;
+
+      component.ngOnChanges({
+         currentPage: new SimpleChange(3, 2, true),
+         total: new SimpleChange(3, 2, true),
+         perPage: new SimpleChange(3, 2, true)
+      });
+
+
+      expect(component.generateItems).not.toHaveBeenCalled();
+      expect(component.onChangePerPage).not.toHaveBeenCalled();
+      expect(component.currentPage).toBe(3);
+      expect(component.total).toBe(3);
+      expect(component.perPage).toBe(3);
+
+      component.ngOnChanges({
+         currentPage: new SimpleChange(3, 2, false)
+      });
+
+      expect(component.currentPage).toBe(2);
+
+      component.ngOnChanges({
+         total: new SimpleChange(3, 2, false)
+      });
+
+      expect(component.generateItems).toHaveBeenCalled();
+
+      component.ngOnChanges({
+         perPage: new SimpleChange(3, 2, false)
+      });
+
+      expect(component.onChangePerPage).toHaveBeenCalled();
+      expect(component.perPage).toBe(2);
+   });
 });

--- a/src/lib/st-pagination/st-pagination.component.ts
+++ b/src/lib/st-pagination/st-pagination.component.ts
@@ -128,11 +128,11 @@ export class StPaginationComponent implements OnInit, OnChanges {
          this.generateItems();
          this.updatePages(false);
       }
-      if (changes.currentPage && changes.currentPage.previousValue !== changes.currentPage.currentValue) {
+      if (changes.currentPage && changes.currentPage.previousValue !== changes.currentPage.currentValue && !changes.currentPage.firstChange) {
          this._currentPage = changes.currentPage.currentValue;
          this.updatePages(false);
       }
-      if (changes.perPage && changes.perPage.previousValue !== changes.perPage.currentValue) {
+      if (changes.perPage && changes.perPage.previousValue !== changes.perPage.currentValue && !changes.perPage.firstChange) {
          this.onChangePerPage(changes.perPage.currentValue);
       }
    }

--- a/src/lib/st-pagination/st-pagination.component.ts
+++ b/src/lib/st-pagination/st-pagination.component.ts
@@ -20,7 +20,6 @@ import {
    SimpleChanges,
    ElementRef
 } from '@angular/core';
-
 import { StDropDownMenuItem } from '../st-dropdown-menu/st-dropdown-menu.interface';
 import { Paginate, PaginateOptions, PaginateTexts } from './st-pagination.interface';
 
@@ -51,9 +50,6 @@ import { Paginate, PaginateOptions, PaginateTexts } from './st-pagination.interf
    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class StPaginationComponent implements OnInit, OnChanges {
-   /** @Input {number} [currentPage=1] Number of the current page */
-   @Input() currentPage: number = 1;
-
    /** @Input {number} [perPage=20] The maximum number of items displayed per page */
    @Input() perPage: number = 20;
 
@@ -78,6 +74,16 @@ export class StPaginationComponent implements OnInit, OnChanges {
     */
    @Output() change: EventEmitter<Paginate> = new EventEmitter<Paginate>();
 
+   /** @Input {number} [currentPage=1] Number of the current page */
+   @Input()
+   get currentPage(): number {
+      return this._currentPage;
+   }
+
+   set currentPage(currentPage: number) {
+      this._currentPage = currentPage;
+   }
+
    public disableNextButton: boolean = false;
    public disablePrevButton: boolean = true;
    public firstItem: number;
@@ -85,10 +91,10 @@ export class StPaginationComponent implements OnInit, OnChanges {
    public items: StDropDownMenuItem[] = [];
    public selectedItem: StDropDownMenuItem;
 
-   constructor(
-      private _cd: ChangeDetectorRef,
-      private _paginationElement: ElementRef
-   ) {
+   private _currentPage: number = 1;
+
+   constructor(private _cd: ChangeDetectorRef,
+               private _paginationElement: ElementRef) {
    }
 
    get hasOptions(): boolean {
@@ -118,15 +124,15 @@ export class StPaginationComponent implements OnInit, OnChanges {
    }
 
    ngOnChanges(changes: SimpleChanges): void {
-      if (changes.total && !changes.total.firstChange) {
+      if (changes.total && changes.total.previousValue !== changes.total.currentValue && !changes.total.firstChange) {
          this.generateItems();
          this.updatePages(false);
       }
-      if (changes.currentPage) {
-         this.currentPage = changes.currentPage.currentValue;
+      if (changes.currentPage && changes.currentPage.previousValue !== changes.currentPage.currentValue) {
+         this._currentPage = changes.currentPage.currentValue;
          this.updatePages(false);
       }
-      if (changes.perPage) {
+      if (changes.perPage && changes.perPage.previousValue !== changes.perPage.currentValue) {
          this.onChangePerPage(changes.perPage.currentValue);
       }
    }
@@ -169,13 +175,13 @@ export class StPaginationComponent implements OnInit, OnChanges {
    }
 
    private updatePages(emit: boolean = true): void {
-      this.lastItem = this.perPage * this.currentPage;
+      this.lastItem = this.perPage * this._currentPage;
 
       if (this.currentPage === 1) {
-         this.firstItem = this.currentPage;
+         this.firstItem = this._currentPage;
          this.disablePrevButton = true;
       } else {
-         this.firstItem = this.perPage * (this.currentPage - 1) + 1;
+         this.firstItem = this.perPage * (this._currentPage - 1) + 1;
          this.disablePrevButton = false;
       }
 
@@ -188,7 +194,7 @@ export class StPaginationComponent implements OnInit, OnChanges {
 
       if (emit) {
          this.change.emit({
-            currentPage: this.currentPage,
+            currentPage: this._currentPage,
             perPage: this.perPage
          });
       }


### PR DESCRIPTION
Closes #UX-35
### Documentation
- [ ] Add the issue in PR description
- [ ] Have changelog updated
- [ ] You fill the milestone value
- [ ] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage