### PR TITLE
CHERY-PICK: fix(st-form): Remove dependant fields when parent does not have any value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 8.6.1 (upcoming)
+
+**Fixed bugs:**
+
+* st-form: Remove dependant fields when parent field does not have any value
+
+
 ## 8.6.0 (March 14, 2018)
 
 **Breaking changes:**

--- a/src/egeo-demo/st-form-demo/json-schema.ts
+++ b/src/egeo-demo/st-form-demo/json-schema.ts
@@ -629,7 +629,8 @@ export const JSON_SCHEMA: any = {
       'dns': {
          'title': 'DNS',
          'description': 'DNS',
-         'type': 'string'
+         'type': 'string',
+         'default': 'default DNS'
       }
    },
    "dependencies": {

--- a/src/lib/st-form/spec/st-form.component.spec.ts
+++ b/src/lib/st-form/spec/st-form.component.spec.ts
@@ -23,8 +23,6 @@ import { StCheckboxModule } from '../../st-checkbox/st-checkbox.module';
 import { StFormFieldModule } from '../st-form-field/st-form-field.module';
 import { CommonModule } from '@angular/common';
 import { StCheckboxComponent } from '../../st-checkbox/st-checkbox.component';
-import { StSwitchComponent } from '../../st-switch/st-switch.component';
-import { StFormFieldComponent } from '../st-form-field/st-form-field.component';
 
 let component: StFormComponent;
 let fixture: ComponentFixture<StFormComponent>;
@@ -248,21 +246,21 @@ describe('StFormComponent', () => {
       beforeEach(() => {
          component.schema = {
             'properties': {
-            'security': {
-               'title': 'Enable security',
+               'security': {
+                  'title': 'Enable security',
                   'description': 'Enable or disable the security',
                   'type': 'boolean'
-            },
-            'dns': {
-               'title': 'DNS',
+               },
+               'dns': {
+                  'title': 'DNS',
                   'description': 'DNS',
                   'type': 'string'
+               }
+            },
+            'dependencies': {
+               'security': ['dns']
             }
-         },
-         'dependencies': {
-            'security': ['dns']
-         }
-      };
+         };
          fixture.changeDetectorRef.detectChanges();
       });
 
@@ -285,6 +283,23 @@ class FormInTemplateDrivenFormComponent {
    public schema: any = _cloneDeep(JSON_SCHEMA);
    public model: any = {};
    @ViewChild('formModel') public formModel: NgForm;
+
+   constructor() {
+      this.schema.properties.security = {
+         'title': 'Enable security',
+         'description': 'Enable or disable the security',
+         'type': 'boolean'
+      };
+      this.schema.properties.dns = {
+         'title': 'DNS',
+         'description': 'DNS',
+         'type': 'string'
+      };
+
+      this.schema.dependencies = {
+         'security': ['dns']
+      };
+   }
 }
 
 
@@ -330,6 +345,31 @@ describe('StFormComponent in templateDriven form', () => {
                expect(templateDrivenFixture.nativeElement.querySelector('#' + propertyId).disabled).toBeFalsy();
             }
          }
+      });
+   });
+
+   it('fields which have a parent field wont be sent when parent is undefined', (done) => {
+      templateDrivenFixture.detectChanges();
+
+      templateDrivenFixture.whenStable().then(() => {
+
+         expect(templateDrivenFixture.nativeElement.querySelector('#security-input')).not.toBeNull();
+         expect(templateDrivenFixture.nativeElement.querySelector('input[name="dns"]')).toBeNull();
+
+         expect(templateDrivenComp.model.dns).toBeUndefined();
+
+         templateDrivenFixture.detectChanges();
+         templateDrivenFixture.nativeElement.querySelector('#security-input').click();
+         templateDrivenFixture.detectChanges();
+
+         expect(templateDrivenComp.model.dns).toEqual(templateDrivenComp.schema.properties.dns.default);
+
+
+         templateDrivenFixture.nativeElement.querySelector('#security-input').click();
+         templateDrivenFixture.detectChanges();
+
+         expect(templateDrivenComp.model.dns).toBeUndefined();
+         done();
       });
    });
 });

--- a/src/lib/st-form/st-form.component.html
+++ b/src/lib/st-form/st-form.component.html
@@ -20,7 +20,7 @@
                      [ngModel]="innerValue[property.key]"
                      (ngModelChange)="onChangeProperty($event, property.key)"
                      [required]="isRequired(property.key)"
-                     [hasDependencies]="hasDependencies(property.key)"
+                     [hasDependencies]="isAParentField(property.key)"
                      [ngClass]="{hidden: isOptionalField(property.key) && !showOptionalFields}"
                      [qaTag]="property.key">
       </st-form-field>


### PR DESCRIPTION

### Documentation
- [ ] Add the issue in PR description
- [ ] Have changelog updated
- [ ] You fill the milestone value
- [ ] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage