### PR TITLE
fix(st-select)[UX-89]: When select is opened after scrolling, its dropdown is not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 8.8.0 (upcoming)
 
-* Pending changelog
+**Fixed bugs:**
+
+* st-select: When select is opened after scrolling, its dropdown is not displayed
+
 
 ## 8.7.0 (March 21, 2018)
 

--- a/src/lib/st-pop/st-pop.component.spec.ts
+++ b/src/lib/st-pop/st-pop.component.spec.ts
@@ -10,8 +10,9 @@
  */
 import { Component, Input, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
 import { StPopComponent } from './st-pop.component';
-import { StPopPlacement, StPopOffset } from './st-pop.model';
+import { StPopPlacement } from './st-pop.model';
 import { StWindowRefService } from '../utils/window-service';
 
 class WindowRefMock {
@@ -112,61 +113,5 @@ describe('StPopComponent', () => {
       fixture.detectChanges();
       let content: HTMLElement = fixture.debugElement.nativeElement.querySelector('#content');
       expect(content.style.transform).toBeUndefined();
-   });
-
-   describe('should be able to listen window scroll and update the item position', () => {
-      let previousPos: StPopOffset;
-      let scrollEvent: Event;
-      let parentDiv: HTMLDivElement;
-
-      beforeEach(() => {
-         component.popComponent.hidden = false;
-         previousPos = component.popComponent.offset;
-         scrollEvent = new CustomEvent('scroll');
-         parentDiv = fixture.nativeElement.querySelector('div');
-      });
-
-      it('if user scrolls page vertically, item position is updated', () => {
-         parentDiv.scrollTop = 5;
-
-         fixture.detectChanges();
-         parentDiv.dispatchEvent(scrollEvent);
-
-         fixture.detectChanges();
-
-         expect(component.popComponent.offset.y).toBe(-5);
-         expect(component.popComponent.offset.x).toBe(previousPos.x);
-
-         parentDiv.scrollTop = 80;
-         fixture.detectChanges();
-         parentDiv.dispatchEvent(scrollEvent);
-
-         fixture.detectChanges();
-
-         expect(component.popComponent.offset.y).toBe(-80);
-         expect(component.popComponent.offset.x).toBe(previousPos.x);
-      });
-
-      it('if user scrolls page horizontally, item position is updated', () => {
-         parentDiv.scrollLeft = 10;
-
-         fixture.detectChanges();
-         parentDiv.dispatchEvent(scrollEvent);
-
-         fixture.detectChanges();
-
-         expect(component.popComponent.offset.y).toBe(previousPos.y);
-         expect(component.popComponent.offset.x).toBe(-10);
-
-         parentDiv.scrollLeft = 100;
-
-         fixture.detectChanges();
-         parentDiv.dispatchEvent(scrollEvent);
-
-         fixture.detectChanges();
-
-         expect(component.popComponent.offset.y).toBe(previousPos.y);
-         expect(component.popComponent.offset.x).toBe(-100);
-      });
    });
 });

--- a/src/lib/st-pop/st-pop.component.ts
+++ b/src/lib/st-pop/st-pop.component.ts
@@ -16,14 +16,10 @@ import {
    ChangeDetectionStrategy,
    OnChanges,
    SimpleChanges,
-   ChangeDetectorRef,
-   HostListener,
-   OnDestroy,
-   NgZone
+   HostListener
 } from '@angular/core';
-import { StPopOffset, StPopPlacement } from './st-pop.model';
-import { StWindowRefService } from '../utils/window-service';
 
+import { StPopOffset, StPopPlacement } from './st-pop.model';
 
 // Internal type
 type StCoords = { x: number, y: number, z: number };
@@ -51,7 +47,7 @@ type StCoords = { x: number, y: number, z: number };
    templateUrl: './st-pop.component.html',
    changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class StPopComponent implements AfterViewInit, OnChanges, OnDestroy {
+export class StPopComponent implements AfterViewInit, OnChanges {
 
    /** @Input {StPopPlacement} [placement=StPopPlacement.BOTOM_START] Define position of content relative to button */
    @Input() placement: StPopPlacement = StPopPlacement.BOTTOM_START;
@@ -66,18 +62,8 @@ export class StPopComponent implements AfterViewInit, OnChanges, OnDestroy {
 
    private button: ClientRect;
    private content: ElementRef;
-   private scrollListener: (event: any) => void;
 
-   constructor(private el: ElementRef, private _windowRefService: StWindowRefService, private _cd: ChangeDetectorRef, private ngZone: NgZone) {
-      this.scrollListener = (event: any) => {
-         this.offset.x = -(event.target.scrollLeft);
-         this.offset.y = -(event.target.scrollTop);
-         this.calculatePosition();
-         this._cd.markForCheck();
-      };
-      this.ngZone.runOutsideAngular(() => {
-         _windowRefService.nativeWindow.addEventListener('scroll', this.scrollListener, true);
-      });
+   constructor(private el: ElementRef) {
    }
 
    ngAfterViewInit(): void {
@@ -86,10 +72,6 @@ export class StPopComponent implements AfterViewInit, OnChanges, OnDestroy {
 
    ngOnChanges(changes: SimpleChanges): void {
       this.calculatePosition();
-   }
-
-   ngOnDestroy(): void {
-      this._windowRefService.nativeWindow.removeEventListener('scroll', this.scrollListener, true);
    }
 
    private getContentElement(): HTMLElement {

--- a/src/lib/st-select/st-select.scss
+++ b/src/lib/st-select/st-select.scss
@@ -25,3 +25,8 @@ input {
       top: 33px;
    }
 }
+
+.st-select-menu {
+   position: relative;
+}
+


### PR DESCRIPTION
Closes #UX-89

### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [x] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage