### PR TITLE
fix(st-select)[UX-93]: Allow to reset value after user selects an empty option

### DIFF
--- a/src/egeo-demo/st-select-demo/select-demo.html
+++ b/src/egeo-demo/st-select-demo/select-demo.html
@@ -11,7 +11,7 @@
 
 -->
 <section class="container-liquid">
-   <st-select placeholder="Select option" [options]="options" [disabled]="disabled">
+   <st-select placeholder="Select option" [options]="options" [disabled]="disabled" [default]="options[2].value">
    </st-select>
 
    <div class="separator"></div>

--- a/src/lib/st-form/st-form-field/st-form-field.component.html
+++ b/src/lib/st-form/st-form-field/st-form-field.component.html
@@ -53,7 +53,7 @@
            [name]="schema.key"
            [placeholder]="placeholder"
            [default]="default"
-           [options]="getSelectOption()"
+           [options]="getSelectOptions()"
            [ngModel]="innerValue"
            (ngModelChange)="setValue($event)"
            [required]="required"
@@ -71,4 +71,3 @@
            [qaTag]="schema.key"
            [id]="qaTag">
 </st-switch>
-

--- a/src/lib/st-form/st-form-field/st-form-field.component.spec.ts
+++ b/src/lib/st-form/st-form-field/st-form-field.component.spec.ts
@@ -11,7 +11,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule, FormControl, FormGroup } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, DebugElement } from '@angular/core';
 import { cloneDeep as _cloneDeep } from 'lodash';
 import { PipesModule } from '../../pipes/pipes.module';
 import { StFormDirectiveModule } from '../../directives/form/form-directives.module';
@@ -27,6 +27,7 @@ import { By } from '@angular/platform-browser';
 import { StSwitchModule } from '../../st-switch/st-switch.module';
 import { StSelectComponent } from '../../st-select/st-select';
 import { StInputComponent } from '../../st-input/st-input.component';
+import { StDropdownMenuComponent } from '../../st-dropdown-menu/st-dropdown-menu.component';
 
 let component: StFormFieldComponent;
 let fixture: ComponentFixture<StFormFieldComponent>;
@@ -41,6 +42,9 @@ describe('StFormFieldComponent', () => {
          declarations: [StFormFieldComponent]
       })
          .overrideComponent(StSelectComponent, {
+            set: { changeDetection: ChangeDetectionStrategy.Default }
+         })
+         .overrideComponent(StDropdownMenuComponent, {
             set: { changeDetection: ChangeDetectionStrategy.Default }
          })
          .overrideComponent(StInputComponent, {
@@ -791,32 +795,28 @@ describe('StFormFieldComponent', () => {
          expect(input.getAttribute('placeholder')).toContain('e.g. ' + fakePlaceholder);
       });
 
-      it('if select has a default value and user interacts with input, he will be able to reset to the default value', () => {
-         let fakeDefault: string = 'test default';
+      it('if select has a default value and user interacts with it, he will be able to reset to the default value', (done) => {
+         let fakeDefault: string = component.schema.value.enum[2];
          component.schema.value.default = fakeDefault;
 
+         const input: HTMLElement = fixture.debugElement.query(By.css('input')).nativeElement;
+         input.click();
+         fixture.detectChanges();
+         let options: DebugElement[] = fixture.debugElement.queryAll(By.css('st-dropdown-menu-item>li'));
+         (options[1].nativeElement as HTMLElement).click();
+
+         input.click();
+         fixture.detectChanges();
+
+         expect(fixture.nativeElement.querySelector('.st-form-control-reset-button')).not.toBeNull();
+
+         fixture.nativeElement.querySelector('.st-form-control-reset-button').click();
          fixture.detectChanges();
 
          fixture.whenStable().then(() => {
             fixture.detectChanges();
-
-            fixture.nativeElement.querySelector('#log_level-input').click();
-            fixture.detectChanges();
-
-            let options: NodeListOf<Element> = fixture.nativeElement.querySelectorAll('.st-dropdown-menu-item');
-            (<HTMLLIElement> options[0]).click();
-            fixture.detectChanges();
-
-            fixture.nativeElement.querySelector('#log_level-input').click();
-            fixture.detectChanges();
-
-            expect(fixture.nativeElement.querySelector('.st-input-reset-button')).not.toBeNull();
-
-            fixture.nativeElement.querySelector('.st-input-reset-button').click();
-            fixture.detectChanges();
-
-            expect(component.value).toEqual(fakeDefault);
-
+            expect(fixture.nativeElement.querySelector('#log_level-input').value).toBe(fakeDefault);
+            done();
          });
       });
    });
@@ -889,7 +889,8 @@ describe('StFormFieldComponent', () => {
          });
       });
    });
-});
+})
+;
 
 
 @Component({

--- a/src/lib/st-form/st-form-field/st-form-field.component.ts
+++ b/src/lib/st-form/st-form-field/st-form-field.component.ts
@@ -203,7 +203,7 @@ export class StFormFieldComponent implements ControlValueAccessor, OnInit {
       }
    }
 
-   getSelectOption(): StDropDownMenuItem[] {
+   getSelectOptions(): StDropDownMenuItem[] {
       let options: StDropDownMenuItem[] = [];
       if (this.schema.value.enum) {
          options.push(<StDropDownMenuItem> { label: 'Select one option', value: undefined });

--- a/src/lib/st-select/st-select.spec.ts
+++ b/src/lib/st-select/st-select.spec.ts
@@ -22,6 +22,7 @@ import { StDropdownMenuComponent } from '../st-dropdown-menu/st-dropdown-menu.co
 
 
 const simpleItems: StDropDownMenuItem[] = [
+   { label: 'example 1', value: undefined },
    { label: 'example 1', value: 1 },
    { label: 'example 2', value: 2 },
    { label: 'example 3', value: 3 },
@@ -401,7 +402,7 @@ describe('StSelectComponent', () => {
       beforeEach(() => {
          comp.label = 'Test';
          comp.options = simpleItems;
-         fakeDefault = simpleItems[2].value;
+         fakeDefault = simpleItems[4].value;
          comp.default = fakeDefault;
          fixture.detectChanges();
          input = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -414,7 +415,7 @@ describe('StSelectComponent', () => {
          items = fixture.debugElement.queryAll(By.css('st-dropdown-menu-item>li'));
 
          expect(fixture.nativeElement.querySelector('.st-form-control-reset-button')).toBeNull();
-         (items[0].nativeElement as HTMLElement).click();
+         (items[1].nativeElement as HTMLElement).click();
          fixture.detectChanges();
 
          input.click();
@@ -430,7 +431,7 @@ describe('StSelectComponent', () => {
          items = fixture.debugElement.queryAll(By.css('st-dropdown-menu-item>li'));
 
          expect(fixture.nativeElement.querySelector('.st-form-control-reset-button')).toBeNull();
-         (items[0].nativeElement as HTMLElement).click();
+         (items[1].nativeElement as HTMLElement).click();
          fixture.detectChanges();
 
          input.click();
@@ -451,7 +452,7 @@ describe('StSelectComponent', () => {
 
          items = fixture.debugElement.queryAll(By.css('st-dropdown-menu-item>li'));
 
-         (items[2].nativeElement as HTMLElement).click();  // select the default option
+         (items[4].nativeElement as HTMLElement).click();  // select the default option
          fixture.detectChanges();
 
          expect(fixture.nativeElement.querySelector('.st-form-control-reset-button')).toBeNull();
@@ -467,7 +468,26 @@ describe('StSelectComponent', () => {
          expect(fixture.nativeElement.querySelector('.st-form-control-reset-button')).toBeNull();
 
          label.click();
-         (items[0].nativeElement as HTMLElement).click();
+         (items[1].nativeElement as HTMLElement).click();
+         fixture.detectChanges();
+
+         label.click();
+         fixture.nativeElement.querySelector('.st-form-control-reset-button').click();
+         fixture.detectChanges();
+
+         expect(comp.selected.value).toEqual(fakeDefault);
+      });
+
+      it ('after user selects an empty option, he can return to the default', () => {
+         const label: HTMLLabelElement = fixture.debugElement.query(By.css('label')).nativeElement;
+         label.click();
+         fixture.detectChanges();
+         items = fixture.debugElement.queryAll(By.css('st-dropdown-menu-item>li'));
+
+         expect(fixture.nativeElement.querySelector('.st-form-control-reset-button')).toBeNull();
+
+         label.click();
+         (items[0].nativeElement as HTMLElement).click(); //empty option
          fixture.detectChanges();
 
          label.click();

--- a/src/lib/st-select/st-select.spec.ts
+++ b/src/lib/st-select/st-select.spec.ts
@@ -22,7 +22,6 @@ import { StDropdownMenuComponent } from '../st-dropdown-menu/st-dropdown-menu.co
 
 
 const simpleItems: StDropDownMenuItem[] = [
-   { label: 'example 1', value: undefined },
    { label: 'example 1', value: 1 },
    { label: 'example 2', value: 2 },
    { label: 'example 3', value: 3 },
@@ -401,8 +400,8 @@ describe('StSelectComponent', () => {
 
       beforeEach(() => {
          comp.label = 'Test';
-         comp.options = simpleItems;
-         fakeDefault = simpleItems[4].value;
+         comp.options = [<StDropDownMenuItem>{ label: 'select one', value: undefined }, ...simpleItems];
+         fakeDefault = comp.options[4].value;
          comp.default = fakeDefault;
          fixture.detectChanges();
          input = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -487,7 +486,7 @@ describe('StSelectComponent', () => {
          expect(fixture.nativeElement.querySelector('.st-form-control-reset-button')).toBeNull();
 
          label.click();
-         (items[0].nativeElement as HTMLElement).click(); //empty option
+         (items[0].nativeElement as HTMLElement).click(); // empty option
          fixture.detectChanges();
 
          label.click();

--- a/src/lib/st-select/st-select.ts
+++ b/src/lib/st-select/st-select.ts
@@ -60,11 +60,15 @@ export class StSelectComponent implements AfterViewInit, ControlValueAccessor {
    expandedMenu: boolean = false;
 
    onChange: (_: any) => void;
-   onTouched: () => void;
+
+   onTouched(): void {
+      this._touched = true;
+   };
 
    private _inputHTMLElement: HTMLInputElement | undefined = undefined;
    private _isDisabled: boolean = false;
    private _options: StDropDownMenuItem[] | StDropDownMenuGroup[] = [];
+   private _touched: boolean = false;
 
    constructor(private _selectElement: ElementRef,
                private _injector: Injector,
@@ -192,8 +196,7 @@ export class StSelectComponent implements AfterViewInit, ControlValueAccessor {
    }
 
    createResetButton(): boolean {
-      return this.default !== undefined && this.selected !== undefined
-         && this.selected.value !== this.default;
+      return this.default !== undefined && ((!this.selected  && this._touched) || (this.selected && this.selected.value !== this.default));
    }
 
    resetToDefault(): void {

--- a/src/lib/st-select/st-select.ts
+++ b/src/lib/st-select/st-select.ts
@@ -61,14 +61,14 @@ export class StSelectComponent implements AfterViewInit, ControlValueAccessor {
 
    onChange: (_: any) => void;
 
-   onTouched(): void {
-      this._touched = true;
-   };
-
    private _inputHTMLElement: HTMLInputElement | undefined = undefined;
    private _isDisabled: boolean = false;
    private _options: StDropDownMenuItem[] | StDropDownMenuGroup[] = [];
    private _touched: boolean = false;
+
+   onTouched(): void {
+      this._touched = true;
+   }
 
    constructor(private _selectElement: ElementRef,
                private _injector: Injector,
@@ -201,6 +201,10 @@ export class StSelectComponent implements AfterViewInit, ControlValueAccessor {
 
    resetToDefault(): void {
       this.writeValue(this.default);
+      this.select.emit(this.default);
+      if (this.onChange) {
+         this.onChange(this.default);
+      }
       this._cd.markForCheck();
    }
 

--- a/src/theme/components/_input.scss
+++ b/src/theme/components/_input.scss
@@ -32,9 +32,3 @@
    font-size: 13px;
    color: $status-critical-default;
 }
-
-.input-container {
-   .st-form-control-reset-button {
-      line-height: 45px;
-   }
-}


### PR DESCRIPTION
Closes #UX-93

### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [x] Review id on demo is the same of egeo folder

### Code
- [x] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage