### PR TITLE
[NA]fix(st-foreground-notifications): Two way binding for visible input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **New features:**
 
 * st-form: Allow to display sections descriptions
-* st-foregroundNotification: two way binding fro visible input
+* st-foreground-notification: two way binding for visible input
 
 **Fixed bugs:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **New features:**
 
 * st-form: Allow to display sections descriptions
+* st-foregroundNotification: two way binding fro visible input
 
 **Fixed bugs:**
 

--- a/src/egeo-demo/st-foreground-notifications-demo/st-foreground-notifications-demo.component.html
+++ b/src/egeo-demo/st-foreground-notifications-demo/st-foreground-notifications-demo.component.html
@@ -13,10 +13,13 @@
 <section class="container-liquid">
    <h1>FOREGROUND NOTIFICATIONS</h1>
    <div class="st-fn-demo-container">
-      <div class="button button-primary" (click)="toggleNotifications()" >
-         <span>Toggle notifications</span>
+      <div  *ngFor="let item of items, let i = index">
+
+         <div class="button button-primary" (click)="toggleNotifications(i)" >
+            <span>Toggle notification</span>
+         </div>
+         <st-foreground-notifications [status]="item.status" [text]="item.text" [(visible)]="item.visible"></st-foreground-notifications>
       </div>
-      <st-foreground-notifications *ngFor="let item of items "[status]="item.status" [text]="item.text" [visible]="isVisible"></st-foreground-notifications>
    </div>
 
 </section>

--- a/src/egeo-demo/st-foreground-notifications-demo/st-foreground-notifications-demo.component.ts
+++ b/src/egeo-demo/st-foreground-notifications-demo/st-foreground-notifications-demo.component.ts
@@ -16,24 +16,27 @@ import { Component } from '@angular/core';
    styleUrls: ['./st-foreground-notifications-demo.component.scss']
 })
 export class StForegroundNotificationsDemoComponent {
-   isVisible: boolean = false;
    items: any[]= [
       {
          text : 'This is a neutral informational notification',
-         status: ''
+         status: '',
+         visible: true
       },
       {
          text : 'This is a successful feedback notification',
-         status: 'success'
+         status: 'success',
+         visible: true
       }, {
          text : 'This is a warning feedback notification',
-         status: 'warning'
+         status: 'warning',
+         visible: true
       }, {
          text : 'This is a critical error feedback notification',
-         status: 'critical'
+         status: 'critical',
+         visible: true
       }
     ];
-  public toggleNotifications(): void {
-    this.isVisible = !this.isVisible;
+  public toggleNotifications(index: number): void {
+    this.items[index].visible = !this.items[index].visible;
   }
 }

--- a/src/lib/st-foreground-notifications/st-foreground-notifications.ts
+++ b/src/lib/st-foreground-notifications/st-foreground-notifications.ts
@@ -8,14 +8,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0.
  */
-import { Component, Input, ChangeDetectorRef, EventEmitter, Output, ElementRef } from '@angular/core';
+import { Component, Input, EventEmitter, Output, ElementRef } from '@angular/core';
 
 @Component({
    selector: 'st-foreground-notifications',
    templateUrl: 'st-foreground-notifications.html',
    styleUrls: ['st-foreground-notifications.scss'],
    host: {
-      '[class.visible]': 'visible'
+      '[class.visible]': '_visible'
    }
 })
 /**
@@ -37,12 +37,25 @@ export class StForegroundNotificationsComponent {
 
 
    /** @Input {bollean} [visible=flase] When true the notification is shown */
-   @Input() visible: boolean = false;
+   @Input()
+   set visible(value: boolean) {
+      if (value !== undefined) {
+         this._visible = value;
+         this.visibleChange.emit(this._visible);
+      }
+   }
+   get visible(): boolean {
+      return this._visible;
+   }
+
    /** @Input {string} [text=''] Displayed text */
    @Input() text: string;
    /** @Input {NotificationStatus} [status='NotificationStatus.default'] Defines the criticality level of the notification */
    @Input() status: string = 'default';
 
+   @Output() visibleChange: EventEmitter<boolean> = new EventEmitter();
+
+   private _visible: boolean = false;
 
    constructor() { }
 


### PR DESCRIPTION
### Documentation
- [ ] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [x] Review id on demo is the same of egeo folder

### Code
- [x] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage