### PR TITLE
[NA] feat(st-input): Label is only generated if it is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Others**
 
 * st-dropdown-menu: Put cursor pointer to items
+* st-input: Label is only generated if it is not empty
 
 
 ## 12.0.0 (August 17, 2018)

--- a/src/lib/st-input/st-input.component.html
+++ b/src/lib/st-input/st-input.component.html
@@ -11,7 +11,7 @@
 
 -->
 
-<label st-label class="st-input__label" [ngClass]="{error: showError(), active: focus, disabled: disabled}" name="name"
+<label *ngIf="label" st-label class="st-input__label" [ngClass]="{error: showError(), active: focus, disabled: disabled}" name="name"
        [attr.id]="labelQaTag" [attr.title]="contextualHelp">
    {{label}}
 </label>

--- a/src/lib/st-input/st-input.component.spec.ts
+++ b/src/lib/st-input/st-input.component.spec.ts
@@ -29,6 +29,9 @@ describe('StInputComponent', () => {
          imports: [FormsModule, ReactiveFormsModule, StLabelModule],
          declarations: [StInputComponent]
       })
+         .overrideComponent(StInputComponent, {
+            set: { changeDetection: ChangeDetectionStrategy.Default }
+         })
          .compileComponents();  // compile template and css
    }));
 
@@ -103,6 +106,18 @@ describe('StInputComponent', () => {
       fixture.detectChanges();
 
       expect(component.blur.emit).toHaveBeenCalledTimes(1);
+   });
+
+   it('label is only generated if label input is not empty', () => {
+      component.label = 'fake label';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('label.st-input__label')).not.toBeNull();
+
+      component.label = '';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('label.st-input__label')).toBeNull();
    });
 
    describe('When a default value is introduced, user will be able to reset the input', () => {


### PR DESCRIPTION
### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage