### PR TITLE
[EGE-433]feat(Global): Replace deprecated dependency with ngx-virtual-scroller

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/test-classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * st-tag-input: Allow to be configured to display an option list without typing anything 
 * st-tag-input: Allow to be configured to allow or avoid to type a free text
-
+* Replace deprecated dependency with ngx-virtual-scroller.
 
 ## 13.3.0 (October 30, 2018)
 

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
    ],
    "dependencies": {
       "@angular/cli": "^6.0.7",
-      "angular2-virtual-scroll": "0.3.1",
       "lodash": "4.17.10",
+      "ngx-virtual-scroller": "^1.0.11",
       "reflect-metadata": "0.1.10",
       "tslib": "1.7.1"
    },
    "devDependencies": {
+      "@angular-devkit/build-angular": "~0.6.6",
       "@angular/animations": "6.0.3",
       "@angular/common": "6.0.3",
       "@angular/compiler": "6.0.3",
@@ -114,8 +115,7 @@
       "typescript": "2.7.2",
       "uglify-js": "2.8.22",
       "word-wrap": "1.2.3",
-      "zone.js": "0.8.26",
-      "@angular-devkit/build-angular": "~0.6.6"
+      "zone.js": "0.8.26"
    },
    "config": {
       "commitizen": {

--- a/src/demo-app/tsconfig-build.json
+++ b/src/demo-app/tsconfig-build.json
@@ -9,7 +9,7 @@
       "emitDecoratorMetadata": true,
       "experimentalDecorators": true,
       "declaration": false,
-      "noImplicitAny": true,
+      "noImplicitAny": false,
       "baseUrl": "./",
       "paths": {
          "@stratio/egeo": ["../lib/public_api"],

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -35,7 +35,7 @@
       "@angular/router": "~4.4.3"
    },
    "dependencies": {
-      "angular2-virtual-scroll": "0.3.0",
+      "ngx-virtual-scroller": "^1.0.11",
       "lodash": "4.17.4",
       "reflect-metadata": "0.1.10",
       "tslib": "1.7.1"

--- a/src/lib/st-item-list/item-list-scroll/item-list-scroll.component.html
+++ b/src/lib/st-item-list/item-list-scroll/item-list-scroll.component.html
@@ -10,6 +10,6 @@
     SPDX-License-Identifier: Apache-2.0.
 
 -->
-<virtual-scroll [items]="list" (update)="scrollItems = $event">
+<virtual-scroller [items]="list" (vsUpdate)="scrollItems = $event">
    <item-list-item *ngFor="let item of scrollItems" [item]="item" [qaTag]="listQaTag" [align]="align" (selectItem)="selectItem.emit(item)"></item-list-item>
-</virtual-scroll>
+</virtual-scroller>

--- a/src/lib/st-item-list/item-list-scroll/item-list-scroll.component.scss
+++ b/src/lib/st-item-list/item-list-scroll/item-list-scroll.component.scss
@@ -19,6 +19,6 @@ item-list-item {
    height: 35px;
 }
 
-virtual-scroll {
+virtual-scroller {
    width: 100%;
 }

--- a/src/lib/st-item-list/item-list-scroll/item-list-scroll.component.spec.ts
+++ b/src/lib/st-item-list/item-list-scroll/item-list-scroll.component.spec.ts
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { VirtualScrollModule } from 'angular2-virtual-scroll';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import { times as _times } from 'lodash';
 
 // Components
@@ -39,7 +39,7 @@ let list: StItemListElement[] = generateData(10);
 describe('StItemListComponent', () => {
    beforeEach(async(() => {
       TestBed.configureTestingModule({
-         imports: [VirtualScrollModule],
+         imports: [VirtualScrollerModule],
          declarations: [ItemListScrollComponent, ItemListItemComponent]
       })
          .compileComponents();  // compile template and css

--- a/src/lib/st-item-list/st-item-list.component.spec.ts
+++ b/src/lib/st-item-list/st-item-list.component.spec.ts
@@ -11,7 +11,7 @@
 import { DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { VirtualScrollModule } from 'angular2-virtual-scroll';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import { times as _times } from 'lodash';
 
 // Components
@@ -49,7 +49,7 @@ let list: StItemListElement[] = generateData(10);
 describe('StItemListComponent', () => {
    beforeEach(async(() => {
       TestBed.configureTestingModule({
-         imports: [StSearchModule, VirtualScrollModule],
+         imports: [StSearchModule, VirtualScrollerModule],
          declarations: [StItemListComponent, ItemListItemComponent, ItemListScrollComponent]
       })
          .compileComponents();  // compile template and css

--- a/src/lib/st-item-list/st-item-list.module.ts
+++ b/src/lib/st-item-list/st-item-list.module.ts
@@ -10,7 +10,7 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { VirtualScrollModule } from 'angular2-virtual-scroll';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 
 // Components
 import { ItemListItemComponent } from './item-list-item/item-list-item.component';
@@ -21,7 +21,7 @@ import { StItemListComponent } from './st-item-list.component';
 import { StSearchModule } from '../st-search/st-search.module';
 
 @NgModule({
-   imports: [CommonModule, StSearchModule, VirtualScrollModule],
+   imports: [CommonModule, StSearchModule, VirtualScrollerModule],
    declarations: [ItemListScrollComponent, ItemListItemComponent, StItemListComponent],
    exports: [StItemListComponent]
 })

--- a/src/lib/st-two-list-selection/list-scroll/list-scroll.component.html
+++ b/src/lib/st-two-list-selection/list-scroll/list-scroll.component.html
@@ -11,7 +11,7 @@
 
 -->
 
-<virtual-scroll [items]="list" (update)="scrollItems = $event">
+<virtual-scroller [items]="list" (vsUpdate)="scrollItems = $event">
    <list-item class="virtual-scroll__list-item" *ngFor="let item of scrollItems; let i = index" [item]="item" (selectItem)="selectItem.emit(item)"
       [qaTag]="listQaTag" [editable]="editable" (selectExtraLabel)="selectExtraLabel.emit($event)" [mode]="mode"></list-item>
-</virtual-scroll>
+</virtual-scroller>

--- a/src/lib/st-two-list-selection/list-scroll/list-scroll.component.scss
+++ b/src/lib/st-two-list-selection/list-scroll/list-scroll.component.scss
@@ -18,7 +18,7 @@
    min-height: 10px;
 }
 
-virtual-scroll {
+virtual-scroller {
    width: 100%;
    &__list-item-all{
       padding: 5px 22px 22px 22px;

--- a/src/lib/st-two-list-selection/list-scroll/list-scroll.component.spec.ts
+++ b/src/lib/st-two-list-selection/list-scroll/list-scroll.component.spec.ts
@@ -12,7 +12,7 @@ import { DebugElement, SimpleChange, SimpleChanges, NO_ERRORS_SCHEMA } from '@an
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Http } from '@angular/http';
 import { By } from '@angular/platform-browser';
-import { VirtualScrollModule } from 'angular2-virtual-scroll';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import {
    times as _times,
    cloneDeep as _cloneDeep
@@ -51,7 +51,7 @@ let list: StTwoListSelectionElement[] = generateData(10);
 describe('StTwoListSelectionComponent', () => {
    beforeEach(async(() => {
       TestBed.configureTestingModule({
-         imports: [StSearchModule, VirtualScrollModule, StCheckboxModule],
+         imports: [StSearchModule, VirtualScrollerModule, StCheckboxModule],
          declarations: [ListScrollComponent, ListItemComponent],
          schemas: [NO_ERRORS_SCHEMA]
       })

--- a/src/lib/st-two-list-selection/list-selection/list-selection.component.spec.ts
+++ b/src/lib/st-two-list-selection/list-selection/list-selection.component.spec.ts
@@ -12,7 +12,7 @@ import { DebugElement, SimpleChange, SimpleChanges, NO_ERRORS_SCHEMA } from '@an
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Http } from '@angular/http';
 import { By } from '@angular/platform-browser';
-import { VirtualScrollModule } from 'angular2-virtual-scroll';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import {
    times as _times,
    cloneDeep as _cloneDeep
@@ -52,7 +52,7 @@ let list: StTwoListSelectionElement[] = generateData(10);
 describe('StTwoListSelectionComponent', () => {
    beforeEach(async(() => {
       TestBed.configureTestingModule({
-         imports: [StSearchModule, VirtualScrollModule, StCheckboxModule],
+         imports: [StSearchModule, VirtualScrollerModule, StCheckboxModule],
          declarations: [ListSelectionComponent, ListItemComponent, ListScrollComponent],
          schemas: [NO_ERRORS_SCHEMA]
       })

--- a/src/lib/st-two-list-selection/st-two-list-selection.component.spec.ts
+++ b/src/lib/st-two-list-selection/st-two-list-selection.component.spec.ts
@@ -12,7 +12,7 @@ import { DebugElement, SimpleChange, SimpleChanges, NO_ERRORS_SCHEMA } from '@an
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Http } from '@angular/http';
 import { By } from '@angular/platform-browser';
-import { VirtualScrollModule } from 'angular2-virtual-scroll';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import {
    times as _times,
    cloneDeep as _cloneDeep
@@ -54,7 +54,7 @@ let selectedElements: StTwoListSelectionElement[] = _cloneDeep(allElements.slice
 describe('StTwoListSelectionComponent', () => {
    beforeEach(async(() => {
       TestBed.configureTestingModule({
-         imports: [StSearchModule, PipesModule, VirtualScrollModule, StCheckboxModule],
+         imports: [StSearchModule, PipesModule, VirtualScrollerModule, StCheckboxModule],
          declarations: [StTwoListSelectionComponent, StTwoListSelectionViewComponent, ListSelectionComponent, ListItemComponent, ListScrollComponent],
          schemas: [NO_ERRORS_SCHEMA]
       })

--- a/src/lib/st-two-list-selection/st-two-list-selection.module.ts
+++ b/src/lib/st-two-list-selection/st-two-list-selection.module.ts
@@ -10,7 +10,7 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { VirtualScrollModule } from 'angular2-virtual-scroll';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 
 // Components
 import { ListItemComponent } from './list-item/list-item.component';
@@ -26,7 +26,7 @@ import { StSelectModule } from '../st-select/st-select.module';
 import { StCheckboxModule } from '../st-checkbox/st-checkbox.module';
 
 @NgModule({
-   imports: [CommonModule, StSearchModule, PipesModule, VirtualScrollModule, StSelectModule, StCheckboxModule],
+   imports: [CommonModule, StSearchModule, PipesModule, VirtualScrollerModule, StSelectModule, StCheckboxModule],
    declarations: [StTwoListSelectionViewComponent, StTwoListSelectionComponent, ListSelectionComponent, ListItemComponent, ListScrollComponent],
    exports: [StTwoListSelectionComponent, StTwoListSelectionViewComponent]
 })

--- a/src/lib/st-two-list-selection/st-two-list-selection.view.component.spec.ts
+++ b/src/lib/st-two-list-selection/st-two-list-selection.view.component.spec.ts
@@ -12,7 +12,7 @@ import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Http } from '@angular/http';
 import { By } from '@angular/platform-browser';
-import { VirtualScrollModule } from 'angular2-virtual-scroll';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import {
    times as _times
 } from 'lodash';
@@ -58,7 +58,7 @@ function generateData(numData: number): StTwoListSelectionElement[] {
 describe('StTwoListSelectionComponent', () => {
    beforeEach(async(() => {
       TestBed.configureTestingModule({
-         imports: [StSearchModule, PipesModule, VirtualScrollModule, StCheckboxModule],
+         imports: [StSearchModule, PipesModule, VirtualScrollerModule, StCheckboxModule],
          declarations: [StTwoListSelectionViewComponent, ListSelectionComponent, ListItemComponent, ListScrollComponent],
          schemas: [NO_ERRORS_SCHEMA]
       })

--- a/tools/package-tools/rollup-helpers.ts
+++ b/tools/package-tools/rollup-helpers.ts
@@ -59,7 +59,7 @@ const ROLLUP_GLOBALS = {
 
    // Other dependencies
    'lodash': 'lodash',
-   'angular2-virtual-scroll': 'angular2-virtual-scroll'
+   'ngx-virtual-scroller': 'ngx-virtual-scroller'
 };
 
 export type BundleConfig = {


### PR DESCRIPTION
Replace deprecated dependency for ngx-virtual-croller.
### Documentation
- [ ] Add the issue in PR description
- [ ] Have changelog updated
- [ ] You fill the milestone value
- [ ] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage