### PR TITLE
[EGE-442] fix(st-breadcrumbs): Allow to configure visualization mode as "default" or "title"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 14.0.0 (upcoming)
 
+**New features:**
+
+* st-breadcrumbs: Allow to configure visualization mode as "default" or "title"
+
 **Breaking changes:**
 
 * st-foreground-notifications: allow to control multiple notifications
@@ -127,7 +131,7 @@
 
 **Breaking changes:**
 
-* st-bread-crumb: Changed options from string to object with label and icon to allow icons
+* st-breadcrumb: Changed options from string to object with label and icon to allow icons
 * st-two-list: Includes checkbox all button in list-scroll component. Emits new event with number of elements selected.
 
 **Others**

--- a/src/egeo-demo/st-breadcrumbs-demo/st-breadcrumbs-demo.html
+++ b/src/egeo-demo/st-breadcrumbs-demo/st-breadcrumbs-demo.html
@@ -22,29 +22,31 @@
     </st-breadcrumbs-item>
 </st-breadcrumbs>
 <br>
-<br>
 <h1>Without ng-content and only icons</h1>
 <st-breadcrumbs [options]="otherOptions" (select)="outputEmitter($event)" qaTag="breadcrumbs2">
 </st-breadcrumbs>
 <br>
-<br><br>
 <h1>Without ng-content and icons or labels</h1>
 <st-breadcrumbs [options]="otherOptions2" (select)="outputEmitter($event)" qaTag="breadcrumbs2">
 </st-breadcrumbs>
 <br>
-<br>
 <h1>Without ng-content, icons and labels and 5 elements max</h1>
 <st-breadcrumbs [options]="options" (select)="outputEmitter($event)" qaTag="breadcrumbs2">
 </st-breadcrumbs>
-
 <br>
 <h1>Without ng-content, icons and labels and 10 elements max</h1>
 <st-breadcrumbs [options]="options" (select)="outputEmitter($event)" qaTag="breadcrumbs3" [elementsToShow]="10">
 </st-breadcrumbs>
+<br>
+<br>
+<h1>Title mode</h1>
+<st-breadcrumbs [options]="options" (select)="outputEmitter($event)" mode="title" qaTag="breadcrumbs4" [elementsToShow]="4">
+</st-breadcrumbs>
 
 <br>
 <br>
 <br>
+
 <button class="button button-primary" (click)="reset()">Reset</button>
 
 <st-demo-logger></st-demo-logger>

--- a/src/lib/st-breadcrumbs/README.md
+++ b/src/lib/st-breadcrumbs/README.md
@@ -4,11 +4,12 @@
 
 ## Inputs
 
-| Property       | Type               | Req   | Description                                       | Default |
-| -------------- | ------------------ | ----- | ------------------------------------------------- | ------- |
-| options        | StBreadCrumbItem[] | False | ] List of navigation parts for show in breadcrumb | \[\     |
-| elementsToShow | Number             | False | Max number of elements to show.                   | 5       |
-| qaTag          | String             | False | Id value for qa test                              | ''      |
+| Property       | Type               | Req   | Description                                       | Default                  |
+| -------------- | ------------------ | ----- | ------------------------------------------------- | ------------------------ |
+| options        | StBreadCrumbItem[] | False | ] List of navigation parts for show in breadcrumb | \[\                      |
+| elementsToShow | Number             | False | Max number of elements to show.                   | 5                        |
+| mode           | StBreadCrumbMode   | False | Visualization mode                                | StBreadCrumbMode.DEFAULT |
+| qaTag          | String             | False | Id value for qa test                              | ''                       |
 
 ## Outputs
 

--- a/src/lib/st-breadcrumbs/st-breadcrumbs-item/st-breadcrumbs-item.component.html
+++ b/src/lib/st-breadcrumbs/st-breadcrumbs-item/st-breadcrumbs-item.component.html
@@ -10,8 +10,8 @@
     SPDX-License-Identifier: Apache-2.0.
 
 -->
-<li class="st-breadcrumbs__item sth-breadcrumbs__item" [ngClass]="{'last': active}" [attr.id]="qaTag">
-    <span class="st-breadcrumbs__item--text sth-breadcrumbs__item--text">
+<li class="st-breadcrumbs__item" [ngClass]="{'last': active}" [attr.id]="qaTag">
+    <span class="st-breadcrumbs__item--text">
       <ng-content select="i"></ng-content>
       <ng-content select="span"></ng-content>
    </span>

--- a/src/lib/st-breadcrumbs/st-breadcrumbs.component.html
+++ b/src/lib/st-breadcrumbs/st-breadcrumbs.component.html
@@ -10,7 +10,7 @@
     SPDX-License-Identifier: Apache-2.0.
 
 -->
-<ul class="st-breadcrumbs" [attr.id]="qaTag">
+<ul class="st-breadcrumbs {{mode}}-mode" [attr.id]="qaTag">
    <ng-content select="st-breadcrumbs-item"></ng-content>
    <div *ngIf="options.length">
       <st-breadcrumbs-item 

--- a/src/lib/st-breadcrumbs/st-breadcrumbs.component.spec.ts
+++ b/src/lib/st-breadcrumbs/st-breadcrumbs.component.spec.ts
@@ -8,12 +8,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0.
  */
-import { SimpleChange } from '@angular/core';
+import { ChangeDetectionStrategy, NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { StBreadCrumbsComponent } from './st-breadcrumbs.component';
-import { StBreadCrumbItem } from './st-breadcrumbs.interface';
+import { StBreadCrumbItem, StBreadCrumbMode } from './st-breadcrumbs.interface';
 
 const item: StBreadCrumbItem = {
    id: 'home',
@@ -29,7 +28,7 @@ describe('StBreadCrumbsComponent', () => {
       { id: 'home', icon: 'icon-home' },
       { id: 'section1', label: 'section1', icon: '' },
       { id: 'section2', label: 'section2', icon: '' },
-      { id: 'section3', label: 'section3'},
+      { id: 'section3', label: 'section3' },
       { id: 'section4', label: 'section4', icon: 'icon-home' },
       { id: 'section5', label: 'section5', icon: '' },
       { id: 'section6', label: 'section6', icon: '' }];
@@ -41,7 +40,11 @@ describe('StBreadCrumbsComponent', () => {
          TestBed.configureTestingModule({
             declarations: [StBreadCrumbsComponent],
             schemas: [NO_ERRORS_SCHEMA]
-         }).compileComponents(); // compile template and css
+         })
+            .overrideComponent(StBreadCrumbsComponent, {
+               set: { changeDetection: ChangeDetectionStrategy.Default }
+            })
+            .compileComponents(); // compile template and css
       })
    );
 
@@ -62,7 +65,7 @@ describe('StBreadCrumbsComponent', () => {
       });
 
       it('should be initialized undefined', () => {
-         const itemUndefined: StBreadCrumbItem = {id: ''};
+         const itemUndefined: StBreadCrumbItem = { id: '' };
          component.options[1] = itemUndefined;
          fixture.detectChanges();
          expect(component.hasLabel(1)).toBeFalsy();
@@ -133,6 +136,7 @@ describe('StBreadCrumbsComponent', () => {
       fixture.detectChanges();
       expect(component.getIcon(4)).toEqual(String(menuMock[4].icon));
    });
+
    it('Should get 3 dots when index is -1', () => {
       fixture.detectChanges();
       expect(component.getLabel(-1)).toEqual('...');
@@ -160,8 +164,28 @@ describe('StBreadCrumbsComponent', () => {
 
       expect(component.indexArray).toEqual([0, 1, 2, 3, 4, 5, 6]);
 
-      component.options = [...menuMock, {id: 'section7', label: 'section7'}];
-      component.ngOnChanges({ options: new SimpleChange(menuMock, component.options, true)});
+      component.options = [...menuMock, { id: 'section7', label: 'section7' }];
+      component.ngOnChanges({ options: new SimpleChange(menuMock, component.options, true) });
       expect(component.indexArray).toEqual([0, -1, 2, 3, 4, 5, 6, 7]);
+   });
+
+   describe('Mode can be configured in order to modify its design', () => {
+      it('If mode is not introduced as input, it will be DEFAULT', () => {
+         fixture.detectChanges();
+
+         expect(fixture.nativeElement.querySelector('ul').classList).toContain('default-mode');
+      });
+
+      it('If mode is introduced as input, it will be added as class to the host', () => {
+         component.mode = StBreadCrumbMode.TITLE;
+         fixture.detectChanges();
+
+         expect(fixture.nativeElement.querySelector('ul').classList).toContain('title-mode');
+
+         component.mode = StBreadCrumbMode.DEFAULT;
+         fixture.detectChanges();
+
+         expect(fixture.nativeElement.querySelector('ul').classList).toContain('default-mode');
+      });
    });
 });

--- a/src/lib/st-breadcrumbs/st-breadcrumbs.component.ts
+++ b/src/lib/st-breadcrumbs/st-breadcrumbs.component.ts
@@ -19,7 +19,7 @@ import {
    SimpleChanges
 } from '@angular/core';
 import { range as _range } from 'lodash';
-import { StBreadCrumbItem } from './st-breadcrumbs.interface';
+import { StBreadCrumbItem, StBreadCrumbMode } from './st-breadcrumbs.interface';
 
 /**
  * @description {Component} [Breadcrumbs]
@@ -55,6 +55,8 @@ export class StBreadCrumbsComponent implements OnInit, OnChanges {
    @Input() options: StBreadCrumbItem[] = [];
    /** @Input {number} [elementsToShow=5] Max number of elements to show. */
    @Input() elementsToShow: number = 5;
+   /** @Input {StBreadCrumbMode} [mode=StBreadCrumbMode.DEFAULT] Visualization mode */
+   @Input() mode: StBreadCrumbMode = StBreadCrumbMode.DEFAULT;
    /** @Input {string} [qaTag=''] Id value for qa test */
    @Input() qaTag: string;
 

--- a/src/lib/st-breadcrumbs/st-breadcrumbs.interface.ts
+++ b/src/lib/st-breadcrumbs/st-breadcrumbs.interface.ts
@@ -14,3 +14,5 @@ export class StBreadCrumbItem {
    label?: string;
    icon?: string;
 }
+
+export enum StBreadCrumbMode { DEFAULT =  <any> 'default', TITLE =  <any> 'title'}

--- a/src/theme/components/_breadcrumbs.scss
+++ b/src/theme/components/_breadcrumbs.scss
@@ -11,7 +11,7 @@
 @import '../constants/colors';
 @import '../constants/fonts';
 
-.sth-breadcrumbs {
+.st-breadcrumbs {
    &__item {
       font-family: $egeo-nunito-sans-semiBold;
       color: $action-primary-default;
@@ -30,6 +30,10 @@
 
          &:hover {
             color: $action-primary-hover;
+         }
+
+         i + span {
+            margin-left: 5px;
          }
       }
 
@@ -50,7 +54,17 @@
          padding-left: 0;
       }
    }
-
 }
 
+.st-breadcrumbs.title-mode {
+   .st-breadcrumbs__item,
+   .st-breadcrumbs__item--text {
+      font-size: $egeo-font-size-xlarge;
+      font-weight: bold;
+      color: $neutral-13;
+   }
+   .st-breadcrumbs__item:after {
+      font-size: $egeo-font-size-small;
+   }
+}
 


### PR DESCRIPTION

### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage