### PR TITLE
[NA] fix(breadcrumbs): Publish StBreadCrumbMode to can be referenced from outside

### DIFF
--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -50,7 +50,8 @@ export { StAlertsService } from './st-alerts/st-alerts.service';
 
 // Breadcrumb
 export {
-   StBreadCrumbItem
+   StBreadCrumbItem,
+   StBreadCrumbMode
 } from './st-breadcrumbs/st-breadcrumbs.interface';
 export { StBreadcrumbsModule } from './st-breadcrumbs/st-breadcrumbs.module';
 


### PR DESCRIPTION


### Documentation
- [x] Add the issue in PR description
- [ ] Have changelog updated
- [ ] You fill the milestone value
- [ ] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage