### PR TITLE
[NA] fix(st-breadcrumb): breadcrumb with a long text displays displaced section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 16.0.0 (upcoming)
+
+**Fixed bugs:**
+
+* st-breadcrumb: Fix style bug when a long text displays displaced section
+
+
+## 15.0.2 (January 16, 2019)
+
+**Fixed bugs:**
+
+* st-table: Remove transition for all attributes in order to prevent a wrong behaviour
+
+
 ## 15.0.1 (January 14, 2019)
 
 **New features:**

--- a/src/egeo-demo/st-breadcrumbs-demo/st-breadcrumbs-demo.html
+++ b/src/egeo-demo/st-breadcrumbs-demo/st-breadcrumbs-demo.html
@@ -43,6 +43,11 @@
    <h1>Title mode</h1>
    <st-breadcrumbs [options]="options" (select)="outputEmitter($event)" mode="title" qaTag="breadcrumbs4" [elementsToShow]="4">
    </st-breadcrumbs>
+   <br>
+   <h1>Breadcrumb with a long text</h1>
+   <st-breadcrumbs [options]="options" (select)="outputEmitter($event)" mode="title" qaTag="breadcrumbs5" 
+      [ngStyle]="{'width': '250px', 'display':'flex', 'border': '1px solid #cdcdcd','padding': '5px'}">
+   </st-breadcrumbs>
 
    <br>
    <br>

--- a/src/lib/st-breadcrumbs/st-breadcrumbs.component.scss
+++ b/src/lib/st-breadcrumbs/st-breadcrumbs.component.scss
@@ -9,6 +9,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 ul {
+   text-overflow: ellipsis;
+   overflow: hidden;
    list-style: none;
    margin: 0;
    padding: 0;


### PR DESCRIPTION

### Documentation
- [ ] Add the issue in PR description
- [x] Have changelog updated
- [ ] You fill the milestone value
- [x] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage