### PR TITLE
Cherry-pick [EGE-477] fix(two-list): Searcher disappears when user is  typing and introduces a text without results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixed bugs:**
 
 * st-breadcrumb, st-modal: Fix style bug when a long text displays displaced section
+* st-two-list: Searcher disappears when user is typing and introduces a text without results
 
 **Breaking changes:**
 

--- a/src/lib/st-two-list-selection/list-selection/list-selection.component.html
+++ b/src/lib/st-two-list-selection/list-selection/list-selection.component.html
@@ -14,7 +14,7 @@
    <div class="list-selection__rectangle">
       <p class="title sth-two-list__list-title" [ngClass]="{'sth-two-list__important-title': important}">{{title}}</p>
       <p class="subtitle sth-two-list__list-subtitle">{{subtitle}}</p>
-      <st-search [disabled]="list.length === 0" class="search" *ngIf="hasSearch && ( list && list.length >= showSearchNumber) || (hasSearch && !showSearchNumber)" [placeholder]="searchPlaceholder" [qaTag]="searchQaTag" (search)="search.emit($event)"></st-search>
+      <st-search class="search" *ngIf="hasSearch && ( list && list.length >= showSearchNumber) || (hasSearch && !showSearchNumber)" [placeholder]="searchPlaceholder" [qaTag]="searchQaTag" (search)="search.emit($event)"></st-search>
    </div>
    <list-item [disabled]="list.length === 0" class="list-selection__list-item-all" *ngIf="hasAllList && scrollItems" [item]="itemAll"
       (selectItem)="selectItem.emit(itemAll);" [editable]="editable" [qaTag]="listCheckAllQaTag"></list-item>

--- a/src/lib/st-two-list-selection/list-selection/list-selection.component.spec.ts
+++ b/src/lib/st-two-list-selection/list-selection/list-selection.component.spec.ts
@@ -28,18 +28,15 @@ import { StSearchModule } from '../../st-search/st-search.module';
 import { StCheckboxModule } from '../../st-checkbox/st-checkbox.module';
 
 // Mdel
-import { StTwoListSelectionConfig, StTwoListSelectionElement } from '../st-two-list-selection.model';
+import { StTwoListSelectionElement } from '../st-two-list-selection.model';
 
 let comp: ListSelectionComponent;
 let fixture: ComponentFixture<ListSelectionComponent>;
-let de: DebugElement;
 
-let listTitle: 'All';
-let listSearchPlaceholder: 'Search all';
 let qaTag: string = 'st-two-list-test';
 
 function generateData(numData: number): StTwoListSelectionElement[] {
-   return _times(10, (i) => {
+   return _times(numData, (i) => {
       return {
          id: i,
          name: i > 5 ? `${i}Element` : `Element${i}`

--- a/src/lib/st-two-list-selection/list-selection/list-selection.component.ts
+++ b/src/lib/st-two-list-selection/list-selection/list-selection.component.ts
@@ -11,7 +11,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { StDropDownMenuItem } from '../../st-dropdown-menu/st-dropdown-menu.interface';
-import { StEgeo, StRequired } from '../../decorators/require-decorators';
+import { StRequired } from '../../decorators/require-decorators';
 import { StTwoListSelectionElement, StTwoListSelectExtraLabelAction } from '../st-two-list-selection.model';
 
 @Component({

--- a/src/lib/st-two-list-selection/st-two-list-selection.spec.ts
+++ b/src/lib/st-two-list-selection/st-two-list-selection.spec.ts
@@ -20,8 +20,8 @@ import { StTwoListSelectionElement } from './st-two-list-selection.model';
 let cd;
 let changeEmitter;
 
-function generateData(): StTwoListSelectionElement[] {
-   return _times(10, (i) => {
+function generateData(numData: number): StTwoListSelectionElement[] {
+   return _times(numData, (i) => {
       return {
          id: i,
          name: i > 5 ? `${i}Element` : `Element${i}`
@@ -29,7 +29,7 @@ function generateData(): StTwoListSelectionElement[] {
    });
 }
 
-let originalAllElements: StTwoListSelectionElement[] = generateData();
+let originalAllElements: StTwoListSelectionElement[] = generateData(10);
 let selectedElements: StTwoListSelectionElement[] = [];
 
 describe('[StTwoListSelection]', () => {


### PR DESCRIPTION

### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [x] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage