### PR TITLE
[EGE-480] feat(st-search): Allow to differentiate search events by its origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 16.0.0 (upcoming)
 
+**New features:**
+
+* st-search: Allow to differentiate search events by its origin
+
 **Fixed bugs:**
 
 * st-breadcrumb, st-modal: Fix style bug when a long text displays displaced section

--- a/angular.json
+++ b/angular.json
@@ -70,6 +70,16 @@
             }
           }
         },
+         "test": {
+            "builder": "@angular-devkit/build-angular:karma",
+            "options": {
+               "main": "test/base.spec.ts",
+               "karmaConfig": "test/karma.conf.js",
+               "tsConfig": "src/demo-app/tsconfig-aot.json",
+               "polyfills": "src/demo-app/polyfills.ts",
+               "scripts": []
+            }
+         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {

--- a/src/lib/public_api.ts
+++ b/src/lib/public_api.ts
@@ -210,6 +210,10 @@ export {
 
 // Search
 export { StSearchModule } from './st-search/st-search.module';
+export {
+   StSearchEvent,
+   StSearchEventOrigin
+} from './st-search/st-search.model';
 
 // Select
 export { StSelectModule } from './st-select/st-select.module';

--- a/src/lib/st-search/st-search.component.spec.ts
+++ b/src/lib/st-search/st-search.component.spec.ts
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0.
  */
-import { DebugElement, SimpleChanges, SimpleChange, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectionStrategy, DebugElement, SimpleChange, SimpleChanges } from '@angular/core';
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -17,6 +17,7 @@ import { StDropdownMenuModule } from '../st-dropdown-menu/st-dropdown-menu.modul
 import { StDropDownMenuItem } from '../st-dropdown-menu/st-dropdown-menu.interface';
 import { StSelectModule } from '../st-select/st-select.module';
 import { StInputModule } from '../st-input/st-input.module';
+import { StSearchEventOrigin } from './st-search.model';
 
 // Component
 
@@ -32,7 +33,7 @@ describe('StSearchComponent', () => {
 
    beforeEach(async(() => {
       TestBed.configureTestingModule({
-         imports: [FormsModule, ReactiveFormsModule, StDropdownMenuModule, StSelectModule, StInputModule],
+         imports: [FormsModule, ReactiveFormsModule, StDropdownMenuModule, StSelectModule, StInputModule, StDropdownMenuModule],
          declarations: [StSearchComponent]
       })
       // remove this block when the issue #12313 of Angular is fixed
@@ -82,7 +83,7 @@ describe('StSearchComponent', () => {
       fixture.detectChanges();
 
       tick(11);
-      expect(component.search.emit).toHaveBeenCalledWith({text: result});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: result, origin: StSearchEventOrigin.INPUT });
    }));
 
    it('should be able to search with the delay introduced as input', fakeAsync(() => {
@@ -99,7 +100,7 @@ describe('StSearchComponent', () => {
       tick(500);
       expect(component.search.emit).not.toHaveBeenCalled();
       tick(501);
-      expect(component.search.emit).toHaveBeenCalledWith({text: result});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: result, origin: StSearchEventOrigin.INPUT });
    }));
 
    it('should be able to search with an updated delay', fakeAsync(() => {
@@ -116,7 +117,7 @@ describe('StSearchComponent', () => {
       tick(500);
       expect(component.search.emit).not.toHaveBeenCalled();
       tick(501);
-      expect(component.search.emit).toHaveBeenCalledWith({text: result});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: result, origin: StSearchEventOrigin.INPUT });
 
       let changes: SimpleChanges = { debounce: new SimpleChange(1000, 250, true) };
       component.debounce = 250;
@@ -132,7 +133,7 @@ describe('StSearchComponent', () => {
       tick(200);
       expect(component.search.emit).not.toHaveBeenCalled();
       tick(55);
-      expect(component.search.emit).toHaveBeenCalledWith({text: result});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: result, origin: StSearchEventOrigin.INPUT });
    }));
 
    it('should search when user types a text with the min length introduced as input', fakeAsync(() => {
@@ -154,7 +155,7 @@ describe('StSearchComponent', () => {
 
       tick(1);
       expect(component.search.emit).toHaveBeenCalled();
-      expect(component.search.emit).toHaveBeenCalledWith({text: 'test'});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: 'test', origin: StSearchEventOrigin.INPUT });
    }));
 
    it('should search when user presses the enter key', () => {
@@ -171,7 +172,7 @@ describe('StSearchComponent', () => {
 
       expect(component.search.emit).toHaveBeenCalled();
       expect(component.search.emit).toHaveBeenCalledTimes(1);
-      expect(component.search.emit).toHaveBeenCalledWith({text: 'te'});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: 'te', origin: StSearchEventOrigin.ENTER });
 
       input.nativeElement.value = 'test';
       input.nativeElement.dispatchEvent(new Event('input'));
@@ -188,14 +189,14 @@ describe('StSearchComponent', () => {
 
       expect(component.search.emit).toHaveBeenCalled();
       expect(component.search.emit).toHaveBeenCalledTimes(2);
-      expect(component.search.emit).toHaveBeenCalledWith({text: 'test'});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: 'test', origin: StSearchEventOrigin.ENTER });
 
       input.triggerEventHandler('keypress', { which: 13 });
       fixture.detectChanges();
 
       expect(component.search.emit).toHaveBeenCalled();
       expect(component.search.emit).toHaveBeenCalledTimes(3);
-      expect(component.search.emit).toHaveBeenCalledWith({text: 'test'});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: 'test', origin: StSearchEventOrigin.ENTER });
    });
 
    it('should be able to search twice', fakeAsync(() => {
@@ -209,7 +210,7 @@ describe('StSearchComponent', () => {
       tick(1);
       expect(component.search.emit).toHaveBeenCalled();
       expect(component.search.emit).toHaveBeenCalledTimes(1);
-      expect(component.search.emit).toHaveBeenCalledWith({text: 'te'});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: 'te', origin: StSearchEventOrigin.INPUT });
 
       input.nativeElement.value = 'te';
       input.nativeElement.dispatchEvent(new Event('input'));
@@ -225,7 +226,7 @@ describe('StSearchComponent', () => {
       tick(1);
       expect(component.search.emit).toHaveBeenCalled();
       expect(component.search.emit).toHaveBeenCalledTimes(2);
-      expect(component.search.emit).toHaveBeenCalledWith({text: 'test'});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: 'test', origin: StSearchEventOrigin.INPUT });
    }));
 
    it('should search when user presses the enter key without liveSearch', () => {
@@ -246,7 +247,7 @@ describe('StSearchComponent', () => {
       fixture.detectChanges();
 
       expect(component.search.emit).toHaveBeenCalled();
-      expect(component.search.emit).toHaveBeenCalledWith({text: 'test'});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: 'test', origin: StSearchEventOrigin.ENTER });
    });
 
    it('should be able to clean the search text when user clicks on the cross button and event is emitted with an empty search', () => {
@@ -268,7 +269,7 @@ describe('StSearchComponent', () => {
       clearButton.nativeElement.dispatchEvent(new Event('mousedown'));
 
       expect(component.searchBox.value).toEqual('');
-      expect(component.search.emit).toHaveBeenCalledWith({text: ''});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: '', origin: StSearchEventOrigin.INPUT });
    });
 
    it('should be able to change initial value of search', () => {
@@ -281,7 +282,7 @@ describe('StSearchComponent', () => {
       expect((<HTMLInputElement>input.nativeElement).value).toEqual('Initial value');
 
       let changes: SimpleChanges = {
-         value: new SimpleChange('Initial value',  'new value', true),
+         value: new SimpleChange('Initial value', 'new value', true),
          liveSearch: new SimpleChange(true, false, true)
       };
 
@@ -332,7 +333,7 @@ describe('StSearchComponent', () => {
       expect(component.isActive).toBeFalsy();
    });
 
-   it('should be able to search with autocomplete', () => {
+   it('should be able to search with autocomplete clicking on an option', () => {
       component.autocompleteList = [{ value: '1', label: '1' }, { value: '2', label: '2' }];
       component.withAutocomplete = true;
 
@@ -345,7 +346,7 @@ describe('StSearchComponent', () => {
       component.changeOption(component.autocompleteList[0]);
       expect(component.search.emit).toHaveBeenCalled();
       expect(component.search.emit).toHaveBeenCalledTimes(1);
-      expect(component.search.emit).toHaveBeenCalledWith({text: component.autocompleteList[0].label});
+      expect(component.search.emit).toHaveBeenCalledWith({ text: component.autocompleteList[0].label, origin: StSearchEventOrigin.LIST });
    });
 
    it('should be able to search with autocomplete', fakeAsync(() => {
@@ -358,7 +359,6 @@ describe('StSearchComponent', () => {
 
       expect(input).toBeDefined();
       expect(dropdownItems.length).toEqual(0);
-
 
       input.value = 'te';
       input.dispatchEvent(new Event('input'));
@@ -453,7 +453,7 @@ describe('StSearchComponent', () => {
 
          fixture.nativeElement.querySelectorAll('.st-dropdown-menu-item')[1].click();
 
-         expect(component.search.emit).toHaveBeenCalledWith({text: '', filter: component.filterOptions[1].value});
+         expect(component.search.emit).toHaveBeenCalledWith({ text: '', filter: component.filterOptions[1].value, origin: StSearchEventOrigin.FILTER });
       });
    });
 });

--- a/src/lib/st-search/st-search.component.ts
+++ b/src/lib/st-search/st-search.component.ts
@@ -10,18 +10,18 @@
  */
 import {
    ChangeDetectionStrategy,
+   ChangeDetectorRef,
    Component,
+   ElementRef,
    EventEmitter,
    Input,
    OnChanges,
    OnDestroy,
    OnInit,
    Output,
-   SimpleChanges,
    Renderer2,
-   ChangeDetectorRef,
-   ViewChild,
-   ElementRef
+   SimpleChanges,
+   ViewChild
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
@@ -29,6 +29,7 @@ import { Subscription } from 'rxjs';
 import { StDropDownMenuItem } from '../st-dropdown-menu/st-dropdown-menu.interface';
 import { EventWindowManager } from '../utils/event-window-manager';
 import { debounceTime } from 'rxjs/operators';
+import { StSearchEvent, StSearchEventOrigin } from './st-search.model';
 
 /**
  * @description {Component} [Search]
@@ -103,7 +104,7 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
    /** @Output { Object(filter?: string, text: string)} [search=''] Event emitted when search is launched. It contains
     * the text typed by the user and the filter value selected (only if filter is displayed)
     */
-   @Output() search: EventEmitter<{filter?: string, text: string}> = new EventEmitter<{filter?: string, text: string}>();
+   @Output() search: EventEmitter<StSearchEvent> = new EventEmitter<StSearchEvent>();
 
    public searchBox: FormControl = new FormControl();
    public showClear: boolean;
@@ -144,7 +145,7 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
    }
 
    public onChangeFilter(): void {
-      this.emitValue(false);
+      this.emitValue(false, StSearchEventOrigin.FILTER);
    }
 
    public ngOnDestroy(): void {
@@ -157,10 +158,10 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
       this.closeElement();
    }
 
-   public launchSearch(force: boolean): void {
+   public launchSearch(force: boolean, origin: StSearchEventOrigin): void {
       if (this.canSearch()) {
          this.showAutoCompleteMenu();
-         this.emitValue(force);
+         this.emitValue(force, origin);
       } else {
          this.closeElement();
       }
@@ -169,7 +170,7 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
    public onKeyPress(event: KeyboardEvent): void {
       let key: number = event.keyCode || event.which;
       if (key === 13) {
-         this.launchSearch(true);
+         this.launchSearch(true, StSearchEventOrigin.ENTER);
       }
    }
 
@@ -179,7 +180,7 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
          this.searchBox.setValue(item.label);
          this.cd.markForCheck();
          this.closeElement();
-         this.emitValue(true);
+         this.emitValue(true, StSearchEventOrigin.LIST);
          this.manageSubscription();
       }
    }
@@ -187,13 +188,13 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
    public clearInput(): void {
       this.searchBox.setValue('');
       this.closeElement();
-      this.emitValue(true);
+      this.emitValue(true, StSearchEventOrigin.INPUT);
    }
 
-   private emitValue(force: boolean): void {
+   private emitValue(force: boolean, origin: StSearchEventOrigin): void {
       if (this.isEqualPrevious(force)) {
          this.lastEmittedText = this.searchBox.value;
-         let newSearch: {filter?: string, text: string} = {text: this.lastEmittedText || ''};
+         let newSearch: StSearchEvent = {text: this.lastEmittedText || '', origin: origin};
          if (this.filter) {
             newSearch.filter = this.filter;
          }
@@ -272,7 +273,7 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
          this.subscriptionSearch = this.searchBox
             .valueChanges.pipe(
             debounceTime(this.debounce))
-            .subscribe((event) => this.launchSearch(false));
+            .subscribe((event) => this.launchSearch(false,  StSearchEventOrigin.INPUT));
       }
    }
 }

--- a/src/lib/st-search/st-search.model.ts
+++ b/src/lib/st-search/st-search.model.ts
@@ -1,0 +1,18 @@
+/*
+ * © 2017 Stratio Big Data Inc., Sucursal en España.
+ *
+ * This software is licensed under the Apache License, Version 2.0.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the terms of the License for more details.
+ *
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+export enum StSearchEventOrigin { INPUT, LIST, FILTER, ENTER }
+
+export class StSearchEvent {
+   text: string;
+   filter?: string;
+   origin?: StSearchEventOrigin;
+}


### PR DESCRIPTION
Now, It is possible to know who emits the search event.  There are four options:

**INPUT** --> Interacting with the textbox
**LIST** --> Clicking on an option from the autocomplete list
**FILTER** --> Changing the current filter
**ENTER**  --> Pressing the enter key


### Documentation
- [x] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [x] You add some label
- [x] Have example running in demo app
- [x] Review id on demo is the same of egeo folder

### Code
- [x] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage