### PR TITLE
[NA] fix(ngx-virtual-scroller): Put version to 3.0.2 to fix compatibility error with internal library tweenjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 13.4.1 (upcoming)
+
+**Fixed bugs:**
+
+* ngx-virtual-scroller: Put version to 3.0.2 to fix compatibility error with internal library tweenjs
+
+
 ## 13.4.0 (November 19, 2018)
 
 **New features:**

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
    "dependencies": {
       "@angular/cli": "^6.0.7",
       "lodash": "4.17.10",
-      "ngx-virtual-scroller": "^1.0.11",
+      "ngx-virtual-scroller": "3.0.2",
       "reflect-metadata": "0.1.10",
       "tslib": "1.7.1"
    },


### PR DESCRIPTION

### Documentation
- [ ] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [ ] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage