### PR TITLE
Cherry pick [NA] fix(ngx-virtual-scroller): Put version to 3.0.2 to fix compatibility error with internal library tweenjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Construction tasks: Fixed package.json main config
 * theme: fix st-widget imports
 * fix prismjs dependency
+* ngx-virtual-scroller: Put version to 3.0.2 to fix compatibility error with internal library tweenjs
 
 **Breaking changes:**
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "@angular/router": "~7.2.15",
       "core-js": "^2.5.4",
       "lodash": "4.17.13",
-      "ngx-virtual-scroller": "^1.0.11",
+      "ngx-virtual-scroller": "3.0.2",
       "reflect-metadata": "0.1.10",
       "rxjs": "~6.3.3",
       "zone.js": "~0.8.26",


### PR DESCRIPTION

### Documentation
- [ ] Add the issue in PR description
- [x] Have changelog updated
- [x] You fill the milestone value
- [ ] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage