### PR TITLE
[NA] fix(st-bubble): Center text when it is shorter than bubble's width

### DIFF
--- a/projects/egeo/src/lib/st-bubble/st-bubble.component.scss
+++ b/projects/egeo/src/lib/st-bubble/st-bubble.component.scss
@@ -25,8 +25,7 @@
 }
 
 .text {
-   display: flex;
-   flex-wrap: nowrap;
-   align-items: center;
-   white-space: nowrap
+   display: block;
+   text-align: center;
+   white-space: nowrap;
 }


### PR DESCRIPTION
### Documentation
- [x] Add the issue in PR description
- [ ] Have changelog updated
- [ ] You fill the milestone value
- [x] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage