### PR TITLE
[NA]feat(st-search): Add new Output event when select a filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * st-menu: Create component
 * grid: Allow to customize max-width with a css variable
 * st-progress-bar: Option for a bigger progress-bar
+* st-search: New Output when select another filter
 
 **Others:**
 

--- a/projects/egeo/src/lib/st-search/st-search.component.html
+++ b/projects/egeo/src/lib/st-search/st-search.component.html
@@ -17,7 +17,7 @@
       [(ngModel)]="filter"
       [disabled]="disabled"
       name="search-filter"
-      (select)="onChangeFilter()"
+      (select)="onChangeFilter($event)"
       class="sth-search-filter st-search-filter"
       [ngClass]="{'disabled': disabled}"
    ></st-select>

--- a/projects/egeo/src/lib/st-search/st-search.component.ts
+++ b/projects/egeo/src/lib/st-search/st-search.component.ts
@@ -108,6 +108,12 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
     * the text typed by the user and the filter value selected (only if filter is displayed)
     */
    @Output() search: EventEmitter<StSearchEvent> = new EventEmitter<StSearchEvent>();
+
+   /** @Output {any} [value=''] Event emitted when filter is changed. It contains
+    * the filter value selected
+    */
+   @Output() selectFilter: EventEmitter<any> = new EventEmitter<any>();
+
    /** @Input {boolean} [keyBoardMove=false] It is needed to activate navigation through options using the keyboard
     */
    @Input() keyBoardMove: boolean = false;
@@ -150,7 +156,8 @@ export class StSearchComponent extends EventWindowManager implements OnChanges, 
       this.checkAutoCompleteMenuChange(changes);
    }
 
-   public onChangeFilter(): void {
+   public onChangeFilter(value: any): void {
+      this.selectFilter.emit(value);
       this.emitValue(false, StSearchEventOrigin.FILTER);
    }
 


### PR DESCRIPTION
before there was only one event to search, but there was no exclusive event for when we changed the filter option.

### Documentation
- [ ] Add the issue in PR description
- [ ] Have changelog updated
- [ ] You fill the milestone value
- [ ] You add some label
- [ ] Have example running in demo app
- [ ] Review id on demo is the same of egeo folder

### Code
- [ ] Pass Sass lint task
- [ ] Have qaTags

### Tests
- [ ] Have at least 70% tests coverage